### PR TITLE
Resolve Regex Issues

### DIFF
--- a/lib/Colour.js
+++ b/lib/Colour.js
@@ -76,9 +76,11 @@ export class Colour {
             return false;
         }
 
-        // if (Colour.regex.test(value) === false) {
-        //     return false;
-        // }
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#using_test_on_a_regex_with_the_global_flag
+        Colour.regex.lastIndex = 0;
+        if (Colour.regex.test(value) === false) {
+            return false;
+        }
 
         if (this.#cache.size < 200) {
             this.#cache.add(value);


### PR DESCRIPTION
#88 shows how this occurred. TL;DR, regex is iterative if the /g flag is applied, this ensures that the index remains at 0 for ALL checks.