### PR TITLE
Issue 35/update

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TaD | 👩🏽‍🏫 & ✏️</title>
-    <script src="./js/playground/dropdownTest.js" type="module" defer></script>
+    <script src="./js/playground/textTest.js" type="module" defer></script>
     <style>
         html, body {
             margin:0px;

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TaD | 👩🏽‍🏫 & ✏️</title>
-    <script src="./js/playground/sliderTest.js" type="module" defer></script>
+    <script src="./js/playground/textTest.js" type="module" defer></script>
     <style>
         html, body {
             margin:0px;

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -25,5 +25,30 @@ function update() {
     slider.draw();
 	$.text.print(400, 300, "Testing!");
 	$.text.print(400, 350, "Testing with max width!", 100);
-	$.text.print(400, 200, 234);
+	// $.text.print(400, 200, 234);
+
+	$.text.alignment.y = "top";
+	$.text.alignment.x = "left";
+	$.text.print(100, 50, "Top Left");
+	$.text.alignment.x = "center";
+	$.text.print(100, 80, "Top Center");
+	$.text.alignment.x = "right";
+	$.text.print(100, 110, "Top Right");
+
+	$.text.alignment.y = "center";
+	$.text.alignment.x = "left";
+	$.text.print(100, 160, "Center Left");
+	$.text.alignment.x = "center";
+	$.text.print(100, 190, "Center Center");
+	$.text.alignment.x = "right";
+	$.text.print(100, 220, "Center Right");
+
+
+	$.text.alignment.y = "bottom";
+	$.text.alignment.x = "left";
+	$.text.print(100, 270, "Bottom Left");
+	$.text.alignment.x = "center";
+	$.text.print(100, 300, "Bottom Center");
+	$.text.alignment.x = "right";
+	$.text.print(100, 330, "Bottom Right");
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -64,4 +64,6 @@ function update() {
 	$.text.alignment.x = "center";
 	$.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
 
+	$.text.print(400, 550, "longsinglewordtoolong and now little words", 100);
+
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -63,7 +63,7 @@ function update() {
 	//testing wrapping
 	$.text.alignment.x = "center";
 	// $.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
-	$.text.hyphenation = false;
+	// $.text.hyphenation = false;
 	$.text.print(400, 500, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianismandevenbiggersonextline it's working?", 100);
 
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -64,6 +64,6 @@ function update() {
 	$.text.alignment.x = "center";
 	// $.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
 
-	$.text.print(400, 550, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianism", 100);
+	$.text.print(400, 500, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianism", 100);
 
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -17,8 +17,9 @@ const button = $.makeButton(
     $.w/2-200,
     $.h/2,
     100,
-    50
-)
+    50,
+	"Multiple lined button!"
+) //test "Multiple-lined button!". For some reason it starts the text on the second line if it cant fit in the first line
 
 function update() {
     button.draw();
@@ -35,6 +36,9 @@ function update() {
 	$.text.alignment.x = "right";
 	$.text.print(100, 110, "Top Right");
 
+	//testing wrapping
+	$.text.print(450, 50, "Y alignment is top, X is right, this is how it wraps", 150);
+
 	$.text.alignment.y = "center";
 	$.text.alignment.x = "left";
 	$.text.print(100, 160, "Center Left");
@@ -43,6 +47,9 @@ function update() {
 	$.text.alignment.x = "right";
 	$.text.print(100, 220, "Center Right");
 
+	//testing wrapping
+	$.text.alignment.x = "left";
+	$.text.print(450, 150, "Y alignment is center, X is left, this is how it wraps", 150);
 
 	$.text.alignment.y = "bottom";
 	$.text.alignment.x = "left";
@@ -51,4 +58,9 @@ function update() {
 	$.text.print(100, 300, "Bottom Center");
 	$.text.alignment.x = "right";
 	$.text.print(100, 330, "Bottom Right");
+
+	//testing wrapping
+	$.text.alignment.x = "center";
+	$.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
+
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -50,6 +50,7 @@ function update() {
 	//testing wrapping
 	$.text.alignment.x = "left";
 	$.text.print(450, 150, "Y alignment is center, X is left, this is how it wraps", 150);
+	$.text.print(550, 500, "Y alignment is center, X is left, this is how it wraps", 100);
 
 	$.text.alignment.y = "bottom";
 	$.text.alignment.x = "left";

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -1,0 +1,28 @@
+import { $ } from "../../lib/Pen.js";
+$.debug = true;
+
+$.use(update);
+const slider = $.makeSlider(    
+    $.w / 2,
+    $.h / 2,
+    350
+);
+// slider.value = 110;
+// slider.max = 100;
+slider.min = -10;
+slider.value = 50;
+slider.max = 100;
+
+const button = $.makeButton(
+    $.w/2-200,
+    $.h/2,
+    100,
+    50
+)
+
+function update() {
+    button.draw();
+    slider.draw();
+	$.text.print(400, 300, "Testing!");
+	$.text.print(400, 350, "Testing with max width!", 100);
+}

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -25,4 +25,5 @@ function update() {
     slider.draw();
 	$.text.print(400, 300, "Testing!");
 	$.text.print(400, 350, "Testing with max width!", 100);
+	$.text.print(400, 200, 234);
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -22,48 +22,48 @@ const button = $.makeButton(
 ) //test "Multiple-lined button!". For some reason it starts the text on the second line if it cant fit in the first line
 
 function update() {
-    button.draw();
-    slider.draw();
-	$.text.print(400, 300, "Testing!");
-	$.text.print(400, 350, "Testing with max width!", 100);
-	// $.text.print(400, 200, 234);
+    // button.draw();
+    // slider.draw();
+	// $.text.print(400, 300, "Testing!");
+	// $.text.print(400, 350, "Testing with max width!", 100);
+	// // $.text.print(400, 200, 234);
 
-	$.text.alignment.y = "top";
-	$.text.alignment.x = "left";
-	$.text.print(100, 50, "Top Left");
-	$.text.alignment.x = "center";
-	$.text.print(100, 80, "Top Center");
-	$.text.alignment.x = "right";
-	$.text.print(100, 110, "Top Right");
+	// $.text.alignment.y = "top";
+	// $.text.alignment.x = "left";
+	// $.text.print(100, 50, "Top Left");
+	// $.text.alignment.x = "center";
+	// $.text.print(100, 80, "Top Center");
+	// $.text.alignment.x = "right";
+	// $.text.print(100, 110, "Top Right");
+
+	// //testing wrapping
+	// $.text.print(450, 50, "Y alignment is top, X is right, this is how it wraps", 150);
+
+	// $.text.alignment.y = "center";
+	// $.text.alignment.x = "left";
+	// $.text.print(100, 160, "Center Left");
+	// $.text.alignment.x = "center";
+	// $.text.print(100, 190, "Center Center");
+	// $.text.alignment.x = "right";
+	// $.text.print(100, 220, "Center Right");
+
+	// //testing wrapping
+	// $.text.alignment.x = "left";
+	// $.text.print(450, 150, "Y alignment is center, X is left, this is how it wraps", 150);
+	// $.text.print(550, 500, "Y alignment is center, X is left, this is how it wraps", 100);
+
+	// $.text.alignment.y = "bottom";
+	// $.text.alignment.x = "left";
+	// $.text.print(100, 270, "Bottom Left");
+	// $.text.alignment.x = "center";
+	// $.text.print(100, 300, "Bottom Center");
+	// $.text.alignment.x = "right";
+	// $.text.print(100, 330, "Bottom Right");
 
 	//testing wrapping
-	$.text.print(450, 50, "Y alignment is top, X is right, this is how it wraps", 150);
-
-	$.text.alignment.y = "center";
-	$.text.alignment.x = "left";
-	$.text.print(100, 160, "Center Left");
 	$.text.alignment.x = "center";
-	$.text.print(100, 190, "Center Center");
-	$.text.alignment.x = "right";
-	$.text.print(100, 220, "Center Right");
+	// $.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
 
-	//testing wrapping
-	$.text.alignment.x = "left";
-	$.text.print(450, 150, "Y alignment is center, X is left, this is how it wraps", 150);
-	$.text.print(550, 500, "Y alignment is center, X is left, this is how it wraps", 100);
-
-	$.text.alignment.y = "bottom";
-	$.text.alignment.x = "left";
-	$.text.print(100, 270, "Bottom Left");
-	$.text.alignment.x = "center";
-	$.text.print(100, 300, "Bottom Center");
-	$.text.alignment.x = "right";
-	$.text.print(100, 330, "Bottom Right");
-
-	//testing wrapping
-	$.text.alignment.x = "center";
-	$.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
-
-	$.text.print(400, 550, "longsinglewordtoolong and now little words", 100);
+	$.text.print(400, 550, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianism", 100);
 
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -7,8 +7,6 @@ const slider = $.makeSlider(
     $.h / 2,
     350
 );
-// slider.value = 110;
-// slider.max = 100;
 slider.min = -10;
 slider.value = 50;
 slider.max = 100;
@@ -19,14 +17,13 @@ const button = $.makeButton(
     100,
     50,
 	"Multiple lined button!"
-) //test "Multiple-lined button!". For some reason it starts the text on the second line if it cant fit in the first line
+)
 
 function update() {
     button.draw();
     slider.draw();
 	$.text.print(400, 300, "Testing!");
 	$.text.print(400, 250, "Testing with max width!", 100);
-	// $.text.print(400, 200, 234);
 
 	$.text.alignment.y = "top";
 	$.text.alignment.x = "left";

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -22,43 +22,42 @@ const button = $.makeButton(
 ) //test "Multiple-lined button!". For some reason it starts the text on the second line if it cant fit in the first line
 
 function update() {
-    // button.draw();
-    // slider.draw();
-	// $.text.print(400, 300, "Testing!");
-	// $.text.print(400, 350, "Testing with max width!", 100);
-	// // $.text.print(400, 200, 234);
+    button.draw();
+    slider.draw();
+	$.text.print(400, 300, "Testing!");
+	$.text.print(400, 250, "Testing with max width!", 100);
+	// $.text.print(400, 200, 234);
 
-	// $.text.alignment.y = "top";
-	// $.text.alignment.x = "left";
-	// $.text.print(100, 50, "Top Left");
-	// $.text.alignment.x = "center";
-	// $.text.print(100, 80, "Top Center");
-	// $.text.alignment.x = "right";
-	// $.text.print(100, 110, "Top Right");
+	$.text.alignment.y = "top";
+	$.text.alignment.x = "left";
+	$.text.print(100, 50, "Top Left");
+	$.text.alignment.x = "center";
+	$.text.print(100, 80, "Top Center");
+	$.text.alignment.x = "right";
+	$.text.print(100, 110, "Top Right");
 
-	// //testing wrapping
-	// $.text.print(450, 50, "Y alignment is top, X is right, this is how it wraps", 150);
+	//testing wrapping
+	$.text.print(450, 50, "Y alignment is top, X is right, this is how it wraps", 150);
 
-	// $.text.alignment.y = "center";
-	// $.text.alignment.x = "left";
-	// $.text.print(100, 160, "Center Left");
-	// $.text.alignment.x = "center";
-	// $.text.print(100, 190, "Center Center");
-	// $.text.alignment.x = "right";
-	// $.text.print(100, 220, "Center Right");
+	$.text.alignment.y = "center";
+	$.text.alignment.x = "left";
+	$.text.print(100, 160, "Center Left");
+	$.text.alignment.x = "center";
+	$.text.print(100, 190, "Center Center");
+	$.text.alignment.x = "right";
+	$.text.print(100, 220, "Center Right");
 
-	// //testing wrapping
-	// $.text.alignment.x = "left";
-	// $.text.print(450, 150, "Y alignment is center, X is left, this is how it wraps", 150);
-	// $.text.print(550, 500, "Y alignment is center, X is left, this is how it wraps", 100);
+	//testing wrapping
+	$.text.alignment.x = "left";
+	$.text.print(450, 150, "Y alignment is center, X is left, this is how it wraps", 150);
 
-	// $.text.alignment.y = "bottom";
-	// $.text.alignment.x = "left";
-	// $.text.print(100, 270, "Bottom Left");
-	// $.text.alignment.x = "center";
-	// $.text.print(100, 300, "Bottom Center");
-	// $.text.alignment.x = "right";
-	// $.text.print(100, 330, "Bottom Right");
+	$.text.alignment.y = "bottom";
+	$.text.alignment.x = "left";
+	$.text.print(100, 270, "Bottom Left");
+	$.text.alignment.x = "center";
+	$.text.print(100, 300, "Bottom Center");
+	$.text.alignment.x = "right";
+	$.text.print(100, 330, "Bottom Right");
 
 	//testing wrapping
 	$.text.alignment.x = "center";

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -64,6 +64,6 @@ function update() {
 	$.text.alignment.x = "center";
 	// $.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
 
-	$.text.print(400, 500, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianism", 100);
+	$.text.print(400, 500, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianismandevenbiggersonextline", 100);
 
 }

--- a/js/playground/textTest.js
+++ b/js/playground/textTest.js
@@ -63,7 +63,7 @@ function update() {
 	//testing wrapping
 	$.text.alignment.x = "center";
 	// $.text.print(450, 250, "Y alignment is bottom, X is center, this is how it wraps", 150);
-
-	$.text.print(400, 500, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianismandevenbiggersonextline", 100);
+	$.text.hyphenation = false;
+	$.text.print(400, 500, "Incomprehensible and incalculable monstrocities with antidisestablishmentarianismandevenbiggersonextline it's working?", 100);
 
 }

--- a/lib/AssetManager.js
+++ b/lib/AssetManager.js
@@ -46,16 +46,16 @@ export class AssetManager {
             if (job.error) {
                 loaded = false;
                 this.#pen.colour.fill = "red";
-                this.#pen.text.print(x, y - 3, "❌");
+                this.#pen.text._print(x, y - 3, "❌");
             } else if (job.completed === false) {
                 loaded = false;
                 this.#pen.colour.fill = "yellow";
-                this.#pen.text.print(x, y - 3, "⏳");
+                this.#pen.text._print(x, y - 3, "⏳");
             } else {
                 this.#pen.colour.fill = "green";
-                this.#pen.text.print(x, y - 3, "✔️");
+                this.#pen.text._print(x, y - 3, "✔️");
             }
-            this.#pen.text.print(x + this.#pen.text.size * 2, y, job.filepath);
+            this.#pen.text._print(x + this.#pen.text.size * 2, y, job.filepath);
             y += this.#pen.text.size * 2;
             if (y > this.#pen.height - this.#pen.text.size * 2) {
                 y = 50;

--- a/lib/Button.js
+++ b/lib/Button.js
@@ -193,7 +193,7 @@ export class Button extends Entity {
         this.#pen.colour.fill = this.background;
         this.#pen.shape.rectangle(this.x, this.y, this.w - 5, this.h - 5);
         this.#pen.colour.fill = this.textColour;
-        this.#pen.text.print(
+        this.#pen.text._print(
             this.x,
             this.y,
             this.label,
@@ -211,7 +211,7 @@ export class Button extends Entity {
         this.#pen.shape.strokeDash=2;
         this.#pen.shape.rectangle(this.x, this.y, this.w - 6, this.h - 6);
         this.#pen.colour.fill = this.textColour;
-        this.#pen.text.print(
+        this.#pen.text._print(
             this.x,
             this.y,
             this.label,
@@ -229,7 +229,7 @@ export class Button extends Entity {
         this.#pen.colour.stroke = this.border;
         this.#pen.shape.rectangle(this.x, this.y, this.w, this.h);
         this.#pen.colour.fill = this.textColour;
-        this.#pen.text.print(
+        this.#pen.text._print(
             this.x,
             this.y,
             this.label,

--- a/lib/Button.js
+++ b/lib/Button.js
@@ -147,22 +147,6 @@ export class Button extends Entity {
     }
 
     /**
-     * Returns the y-coordinate of the text label adjusted for multi-line, wrapped text.
-     * @returns {number}
-     */
-    adjustedLineY() {
-        let textY = this.y;
-        let textMaxW = this.w - this.w / (2 * this.#pen.text.size);
-        if (this.#pen.context.measureText(this.label).width > textMaxW) {
-            let subtract = Math.floor(
-                this.#pen.context.measureText(this.label).width / textMaxW
-            );
-            textY = textY - subtract * 0.5 * this.#pen.text.size;
-        }
-        return textY;
-    }
-
-    /**
      * Draws the button's decorative elements (if any).
      */
     drawDecorations() {
@@ -211,7 +195,7 @@ export class Button extends Entity {
         this.#pen.colour.fill = this.textColour;
         this.#pen.text.print(
             this.x,
-            this.adjustedLineY(),
+            this.y,
             this.label,
             this.w - this.w / (2 * this.#pen.text.size)
         );
@@ -229,7 +213,7 @@ export class Button extends Entity {
         this.#pen.colour.fill = this.textColour;
         this.#pen.text.print(
             this.x,
-            this.adjustedLineY(),
+            this.y,
             this.label,
             this.w - this.w / (2 * this.#pen.text.size)
         );
@@ -247,7 +231,7 @@ export class Button extends Entity {
         this.#pen.colour.fill = this.textColour;
         this.#pen.text.print(
             this.x,
-            this.adjustedLineY(),
+            this.y,
             this.label,
             this.w - this.w / (2 * this.#pen.text.size)
         );

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -371,8 +371,6 @@ export class Debug {
                 x = left + maxWidth / 2;
             }
             pen.shape.rectangle(x, centerY - height / 2 + yAdjustment, maxWidth, totalHeight);
-            //adjust the height to be multiplied by how many lines are created,
-            //so that it looks like an actual textbox?
         }
 
         pen.shape.strokeDash = 0;

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -658,7 +658,7 @@ export class Debug {
             );
 
             pen.colour.fill = DULL_GREEN;
-            pen.text.print(i * INCREMENT, INCREMENT - 5, i * INCREMENT);
+            pen.text.print(i * INCREMENT, INCREMENT - 5, `${i * INCREMENT}`);
         }
 
         // Drawing horizontal tags
@@ -673,7 +673,7 @@ export class Debug {
                     LABELHEIGHT
                 );
                 pen.colour.fill = DULL_GREEN;
-                pen.text.print(INCREMENT, INCREMENT * y - 5, y * INCREMENT);
+                pen.text.print(INCREMENT, INCREMENT * y - 5, `${y * INCREMENT}`);
             }
         }
     }

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -350,6 +350,14 @@ export class Debug {
         pen.shape.strokeDash = 2;
         pen.shape.rectangle(centerX, centerY, width, height);
 
+        const totalHeight = height * numLines;
+        let yAdjustment = 0 + height / 2; // center alignment
+        if (pen.text.alignment.y === "top") {
+            yAdjustment = totalHeight / 2;
+        } else if (pen.text.alignment.y === "bottom") {
+            yAdjustment = -totalHeight / 2 + height;
+        }
+
         // Draw debug for when multiline
         if (maxWidth > 0) {
             pen.colour.stroke = "red";
@@ -360,7 +368,7 @@ export class Debug {
             } else if (pen.context.textAlign === "left") {
                 x = left + maxWidth / 2;
             }
-            pen.shape.rectangle(x, centerY, maxWidth, height * numLines);
+            pen.shape.rectangle(x, centerY - height / 2 + yAdjustment, maxWidth, totalHeight);
             //adjust the height to be multiplied by how many lines are created,
             //so that it looks like an actual textbox?
         }

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -280,12 +280,12 @@ export class Debug {
             // pen.text.size = TEXT_SIZE;
             // pen.colour.fill = COLOURS.BLACK;
             // pen.text.alignment.x = "center";
-            // pen.text.print(collider.x, collider.y, `x:${parseInt(collider.x)}`);
-            // pen.text.print(collider.x, collider.y+pen.text.size*1, `y:${parseInt(collider.y)}`);
+            // pen.text._print(collider.x, collider.y, `x:${parseInt(collider.x)}`);
+            // pen.text._print(collider.x, collider.y+pen.text.size*1, `y:${parseInt(collider.y)}`);
         }
 
         if (collider.exists === false) {
-            pen.text.print(x, y, "💀");
+            pen.text._print(x, y, "💀");
         }
 
         Debug.cross(pen, x, y);
@@ -317,7 +317,7 @@ export class Debug {
         pen.shape.rectangle(LEFT, TOP, BAR_WIDTH, BAR_HEIGHT);
 
         pen.colour.fill = COLOURS.GREEN;
-        pen.text.print(2, 10, `frame:${pen.frameCount}`);
+        pen.text._print(2, 10, `frame:${pen.frameCount}`);
 
         pen.state.load();
     }
@@ -417,7 +417,7 @@ export class Debug {
             pen.shape.rectangle(BOX_X, Y, BOX_WIDTH + 100, BOX_HEIGHT);
 
             pen.colour.fill = COLOURS.GREEN;
-            pen.text.print(X, Y, `⌨️ ${key}: ${keys.keys[key].frames} fr`);
+            pen.text._print(X, Y, `⌨️ ${key}: ${keys.keys[key].frames} fr`);
 
             pen.state.load();
         }
@@ -505,8 +505,8 @@ export class Debug {
 
             //green text on top
             pen.colour.fill = "white";
-            pen.text.print(X, Y - pen.text.size, `x:${parseInt(mouse.x)}`);
-            pen.text.print(X, Y, `y:${parseInt(mouse.y)}`);
+            pen.text._print(X, Y - pen.text.size, `x:${parseInt(mouse.x)}`);
+            pen.text._print(X, Y, `y:${parseInt(mouse.y)}`);
         }
 
         pen.colour.stroke = Paint.clear;
@@ -672,7 +672,7 @@ export class Debug {
         Debug.cross(pen, center.x + offset.x, center.y + offset.y);
         pen.text.alignment.x = "center";
         pen.text.alignment.y = "center";
-        pen.text.print(center.x, center.y + 4, "🎥");
+        pen.text._print(center.x, center.y + 4, "🎥");
         pen.state.load();
     }
 
@@ -711,7 +711,7 @@ export class Debug {
             );
 
             pen.colour.fill = DULL_GREEN;
-            pen.text.print(i * INCREMENT, INCREMENT - 5, `${i * INCREMENT}`);
+            pen.text._print(i * INCREMENT, INCREMENT - 5, `${i * INCREMENT}`);
         }
 
         // Drawing horizontal tags
@@ -726,7 +726,7 @@ export class Debug {
                     LABELHEIGHT
                 );
                 pen.colour.fill = DULL_GREEN;
-                pen.text.print(INCREMENT, INCREMENT * y - 5, `${y * INCREMENT}`);
+                pen.text._print(INCREMENT, INCREMENT * y - 5, `${y * INCREMENT}`);
             }
         }
     }
@@ -770,7 +770,7 @@ export class Debug {
         pen.shape.rectangle(btn.x, btn.y, btn.w, btn.h);
         pen.colour.fill = strokeColour;
 
-        pen.text.print(btn.x, btn.y + 20, btn.label);
+        pen.text._print(btn.x, btn.y + 20, btn.label);
         for (let i = 0; i < btn.w / 10; i++) {
             let x1 = btn.x - HORIZONTAL_OFFSET + i * 10 + 20;
             let y1 = btn.y - VERTICAL_OFFSET;
@@ -784,7 +784,7 @@ export class Debug {
 
         pen.shape.oval(btn.x, btn.y, pen.text.size);
         pen.colour.fill = COLOURS.BLACK;
-        pen.text.print(btn.x, btn.y, `${btn.id}`);
+        pen.text._print(btn.x, btn.y, `${btn.id}`);
 
         pen.shape.rectangle(
             btn.x,
@@ -793,7 +793,7 @@ export class Debug {
             pen.text.size * 1.5
         );
         pen.colour.fill = COLOURS.GREEN;
-        pen.text.print(btn.x, btn.y - VERTICAL_OFFSET + 7, `👆 Btn`);
+        pen.text._print(btn.x, btn.y - VERTICAL_OFFSET + 7, `👆 Btn`);
         pen.state.load();
     }
 
@@ -815,7 +815,7 @@ export class Debug {
 
         pen.shape.rectangle(btn.x, btn.y, btn.w, btn.h);
         pen.colour.fill = COLOURS.BLACK;
-        pen.text.print(btn.x, btn.y + 20, btn.label);
+        pen.text._print(btn.x, btn.y + 20, btn.label);
 
         const y1 = btn.y - btn.h / 2;
         const y2 = btn.y + btn.h / 2;
@@ -831,12 +831,12 @@ export class Debug {
 
         pen.shape.oval(btn.x, btn.y, 10);
         pen.colour.fill = COLOURS.GREEN;
-        pen.text.print(btn.x, btn.y, `${btn.id}`);
+        pen.text._print(btn.x, btn.y, `${btn.id}`);
 
         pen.colour.fill = COLOURS.BLACK;
         pen.shape.rectangle(btn.x, btn.y - btn.h / 2 + 7, btn.w, 15);
         pen.colour.fill = COLOURS.GREEN;
-        pen.text.print(btn.x, btn.y - btn.h / 2 + 7, `👆 Btn`);
+        pen.text._print(btn.x, btn.y - btn.h / 2 + 7, `👆 Btn`);
         pen.state.load();
     }
 
@@ -872,7 +872,7 @@ export class Debug {
         pen.shape.line(halfWidth, -halfHeight, -halfWidth, halfHeight);
         pen.shape.line(-halfWidth, -halfHeight, halfWidth, halfHeight);
 
-        pen.text.print(
+        pen.text._print(
             NEW_X - 36,
             NEW_Y - halfHeight - 5,
             `x:${parseInt(img.x)}, y:${parseInt(img.y)}`
@@ -881,7 +881,7 @@ export class Debug {
         pen.shape.rectangle(NEW_X, NEW_Y - halfHeight, img.w, 15);
         pen.colour.fill = COLOURS.IMG_ORANGE;
         pen.text.alignment.x = "center";
-        pen.text.print(NEW_X, NEW_Y - halfHeight, `🎨 Img`);
+        pen.text._print(NEW_X, NEW_Y - halfHeight, `🎨 Img`);
 
         //static label
         const LABELWIDTH = 115;
@@ -898,11 +898,11 @@ export class Debug {
         pen.colour.fill = COLOURS.IMG_ORANGE;
         pen.shape.oval(NEW_X, NEW_Y, 10);
         pen.colour.fill = COLOURS.BLACK;
-        pen.text.print(NEW_X, NEW_Y, `${img.id}`);
+        pen.text._print(NEW_X, NEW_Y, `${img.id}`);
         pen.colour.fill = COLOURS.IMG_ORANGE;
 
         pen.text.alignment.x = "left";
-        pen.text.print(
+        pen.text._print(
             NEW_X + 15,
             NEW_Y,
             `x:${parseInt(img.x)} y:${parseInt(img.y)} rot:${img.rotation}`

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -330,7 +330,7 @@ export class Debug {
      * @param {string} msg - The text portion of the text.
      * @static
      */
-    static drawText(pen, x, y, msg) {
+    static drawText(pen, x, y, msg, maxWidth) {
         pen.state.save();
         Debug.cross(pen, x, y, 'yellow');
 
@@ -341,11 +341,26 @@ export class Debug {
         const bottom = y + textMeasureObj.actualBoundingBoxDescent;
         const width = textMeasureObj.actualBoundingBoxLeft + textMeasureObj.actualBoundingBoxRight;
         const height = textMeasureObj.actualBoundingBoxAscent + textMeasureObj.actualBoundingBoxDescent;
-
+        const centerX = (left + right) / 2;
+        const centerY = (top + bottom) / 2;
         pen.colour.fill = "transparent";
         pen.colour.stroke = "grey";
         pen.shape.strokeDash = 2;
-        pen.shape.rectangle((left + right) / 2, (top + bottom) / 2, width, height);
+        pen.shape.rectangle(centerX, centerY, width, height);
+
+        if (maxWidth > 0) {
+            pen.colour.stroke = "red";
+            pen.shape.strokeDash = 1;
+            let x = centerX;
+            if (pen.context.textAlign === "right") {
+                x = right - maxWidth / 2;
+            } else if (pen.context.textAlign === "left") {
+                x = left + maxWidth / 2;
+            }
+            pen.shape.rectangle(x, centerY, maxWidth, height);
+            //adjust the height to be multiplied by how many lines are created,
+            //so that it looks like an actual textbox?
+        }
 
         pen.shape.strokeDash = 0;
         pen.state.load();

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -332,6 +332,8 @@ export class Debug {
      */
     static drawText(pen, x, y, msg, maxWidth, numLines) {
         pen.state.save();
+        pen.shape.alignment.x = "center";
+        pen.shape.alignment.y = "center";
 
         // Draw debug for when multiline or not
         Debug.cross(pen, x, y, 'yellow');

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -330,8 +330,10 @@ export class Debug {
      * @param {string} msg - The text portion of the text.
      * @static
      */
-    static drawText(pen, x, y, msg, maxWidth) {
+    static drawText(pen, x, y, msg, maxWidth, numLines) {
         pen.state.save();
+
+        // Draw debug for when multiline or not
         Debug.cross(pen, x, y, 'yellow');
 
         const textMeasureObj = pen.context.measureText(msg);
@@ -348,6 +350,7 @@ export class Debug {
         pen.shape.strokeDash = 2;
         pen.shape.rectangle(centerX, centerY, width, height);
 
+        // Draw debug for when multiline
         if (maxWidth > 0) {
             pen.colour.stroke = "red";
             pen.shape.strokeDash = 1;
@@ -357,7 +360,7 @@ export class Debug {
             } else if (pen.context.textAlign === "left") {
                 x = left + maxWidth / 2;
             }
-            pen.shape.rectangle(x, centerY, maxWidth, height);
+            pen.shape.rectangle(x, centerY, maxWidth, height * numLines);
             //adjust the height to be multiplied by how many lines are created,
             //so that it looks like an actual textbox?
         }

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -342,7 +342,7 @@ export class Debug {
         const top = y - textMeasureObj.actualBoundingBoxAscent;
         const bottom = y + textMeasureObj.actualBoundingBoxDescent;
         const width = textMeasureObj.actualBoundingBoxLeft + textMeasureObj.actualBoundingBoxRight;
-        const height = textMeasureObj.actualBoundingBoxAscent + textMeasureObj.actualBoundingBoxDescent;
+        const height = pen.text.size;
         const centerX = (left + right) / 2;
         const centerY = (top + bottom) / 2;
         pen.colour.fill = "transparent";

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -1,7 +1,7 @@
 import { Collider } from "./Collider.js";
 import { Group } from "./Group.js";
 import { Paint } from "./Paint.js";
-import { Pen } from "./Pen.js";
+import { Pen, text } from "./Pen.js";
 const COLOURS = {
     BLACK: "black",
     GREEN: "green",
@@ -327,13 +327,27 @@ export class Debug {
      * @param {Pen} pen - The pen object to draw with.
      * @param {number} x - The x-coordinate to draw the text.
      * @param {number} y - The y-coordinate to draw the text.
-     * @param {number} w - The width of the text.
-     * @param {number} h - The height of the text.
+     * @param {string} msg - The text portion of the text.
      * @static
      */
-    static drawText(pen, x, y, w, h) {
+    static drawText(pen, x, y, msg) {
         pen.state.save();
-        // Debug.cross(pen,x,y);
+        Debug.cross(pen, x, y, 'yellow');
+
+        const textMeasureObj = pen.context.measureText(msg);
+        const left = x - textMeasureObj.actualBoundingBoxLeft;
+        const right = x + textMeasureObj.actualBoundingBoxRight;
+        const top = y - textMeasureObj.actualBoundingBoxAscent;
+        const bottom = y + textMeasureObj.actualBoundingBoxDescent;
+        const width = textMeasureObj.actualBoundingBoxLeft + textMeasureObj.actualBoundingBoxRight;
+        const height = textMeasureObj.actualBoundingBoxAscent + textMeasureObj.actualBoundingBoxDescent;
+
+        pen.colour.fill = "transparent";
+        pen.colour.stroke = "grey";
+        pen.shape.strokeDash = 2;
+        pen.shape.rectangle((left + right) / 2, (top + bottom) / 2, width, height);
+
+        pen.shape.strokeDash = 0;
         pen.state.load();
     }
 

--- a/lib/DrawStateManager.js
+++ b/lib/DrawStateManager.js
@@ -62,6 +62,7 @@ export class DrawStateManager {
         this.#pen.colour.stroke = "white";
 
         this.#pen.text.bold = false;
+        this.#pen.text.hyphenation = true;
         this.#pen.text.italic = false;
         this.#pen.text.alignment.x = "center";
         this.#pen.text.alignment.y = "center";
@@ -86,6 +87,7 @@ export class DrawState {
      * @property {string} textAlignmentX - The x-axis alignment of the current state.
      * @property {string} textAlignmentY - The y-axis alignment of the current state.
      * @property {boolean} textBold - The bold property of the current state.
+     * @property {boolean} textHyphenation - The hyphenation property of the current state.
      * @property {boolean} textItalic - The italic property of the current state.
      * @property {number} textSize - The text size of the current state.
      * @property {string} textFont - The text font of the current state.
@@ -103,6 +105,7 @@ export class DrawState {
         this.textAlignmentX = pen.text.alignment.x;
         this.textAlignmentY = pen.text.alignment.y;
         this.textBold = pen.text.bold;
+        this.textHyphenation = pen.text.hyphenation;
         this.textItalic = pen.text.italic;
         this.textSize = 16;
         this.textFont = pen.text.font;

--- a/lib/Dropdown.js
+++ b/lib/Dropdown.js
@@ -405,7 +405,7 @@ export class Dropdown extends ShapedAssetEntity {
 				// Options
 				this.#pen.colour.fill = this.textColour;
 				this.#pen.text.alignment.x = "left";
-				const adjustment = 15;
+				const adjustment = this.h / 2;
 				// Account for text being too long, truncate if needed
 				const maxWidth = this.w - this.#borderWidth * 2 - 4;
 				for (let i = 0; i < this.#options.length; i++) {
@@ -486,7 +486,7 @@ export class Dropdown extends ShapedAssetEntity {
 	#isHoverOnOption(index) {
 		const directionModifier = this.#openDirection === "up" ? -1 : 1;
 		const optionHeight = this.h - this.#borderWidth * 2;
-		const adjustment = 15;
+		const adjustment = this.h / 2;
 		return Dropdown.#isInRect(
 			this.#pen.mouse.x,
 			this.#pen.mouse.y,
@@ -566,7 +566,7 @@ export class Dropdown extends ShapedAssetEntity {
 
 		const directionModifier = this.#openDirection === "up" ? -1 : 1;
 		const optionHeight = this.h - this.#borderWidth * 2;
-		const adjustment = 15;
+		const adjustment = this.h / 2;
 
 		this.#pen.shape.rectangle(
 			this.x,
@@ -593,7 +593,7 @@ export class Dropdown extends ShapedAssetEntity {
    	#drawFocusedOption() {
 		const directionModifier = this.#openDirection === "up" ? -1 : 1;
 		const optionHeight = this.h - this.#borderWidth * 2;
-		const adjustment = 15;
+		const adjustment = this.h / 2;
 		this.#pen.colour.fill = this.secondaryColour;
 		this.#pen.shape.rectangle(
 			this.x,

--- a/lib/Dropdown.js
+++ b/lib/Dropdown.js
@@ -410,7 +410,7 @@ export class Dropdown extends ShapedAssetEntity {
 				const maxWidth = this.w - this.#borderWidth * 2 - 4;
 				for (let i = 0; i < this.#options.length; i++) {
 					const text = this.#truncate(this.#options[i], maxWidth);
-					this.#pen.text.print(
+					this.#pen.text._print(
 						this.x - this.w / 2 + this.#borderWidth + 2, 
 						this.y + directionModifier * (this.h / 2 + optionHeight * i + adjustment), 
 						text
@@ -634,7 +634,7 @@ export class Dropdown extends ShapedAssetEntity {
 		const maxWidth = this.w - buttonWidth - this.#borderWidth * 2 - 4;
 		this.#pen.colour.fill = this.textColour;
 		this.#pen.text.alignment.x = "left";
-		this.#pen.text.print(
+		this.#pen.text._print(
 			this.x - this.w / 2 + this.#borderWidth + 2, 
 			this.y, 
 			this.#truncate(this.#options[this.#index], maxWidth)

--- a/lib/Dropdown.js
+++ b/lib/Dropdown.js
@@ -405,8 +405,7 @@ export class Dropdown extends ShapedAssetEntity {
 				// Options
 				this.#pen.colour.fill = this.textColour;
 				this.#pen.text.alignment.x = "left";
-				const adjustment = this.#openDirection === "up" ? 10 : 18; // To account for text not being centered
-
+				const adjustment = 15;
 				// Account for text being too long, truncate if needed
 				const maxWidth = this.w - this.#borderWidth * 2 - 4;
 				for (let i = 0; i < this.#options.length; i++) {
@@ -487,7 +486,7 @@ export class Dropdown extends ShapedAssetEntity {
 	#isHoverOnOption(index) {
 		const directionModifier = this.#openDirection === "up" ? -1 : 1;
 		const optionHeight = this.h - this.#borderWidth * 2;
-		const adjustment = this.#openDirection === "up" ? 10 : 18; // To account for text not being centered
+		const adjustment = 15;
 		return Dropdown.#isInRect(
 			this.#pen.mouse.x,
 			this.#pen.mouse.y,
@@ -567,7 +566,7 @@ export class Dropdown extends ShapedAssetEntity {
 
 		const directionModifier = this.#openDirection === "up" ? -1 : 1;
 		const optionHeight = this.h - this.#borderWidth * 2;
-		const adjustment = this.#openDirection === "up" ? 15 : 14; // To account for text not being centered
+		const adjustment = 15;
 
 		this.#pen.shape.rectangle(
 			this.x,
@@ -594,7 +593,7 @@ export class Dropdown extends ShapedAssetEntity {
    	#drawFocusedOption() {
 		const directionModifier = this.#openDirection === "up" ? -1 : 1;
 		const optionHeight = this.h - this.#borderWidth * 2;
-		const adjustment = this.#openDirection === "up" ? 15 : 14; // To account for text not being centered
+		const adjustment = 15;
 		this.#pen.colour.fill = this.secondaryColour;
 		this.#pen.shape.rectangle(
 			this.x,
@@ -637,7 +636,7 @@ export class Dropdown extends ShapedAssetEntity {
 		this.#pen.text.alignment.x = "left";
 		this.#pen.text.print(
 			this.x - this.w / 2 + this.#borderWidth + 2, 
-			this.y + 5, 
+			this.y, 
 			this.#truncate(this.#options[this.#index], maxWidth)
 		);
 		this.#pen.text.alignment.x = "center";

--- a/lib/Slider.js
+++ b/lib/Slider.js
@@ -547,7 +547,7 @@ export class Slider extends ShapedAssetEntity {
 
 				);
 				this.#pen.colour.fill = this.textColour;
-				this.#pen.text.print(xPos, yPos + this.h / 2, this.#value.toString());
+				this.#pen.text.print(xPos, yPos, this.#value.toString());
 				break;
 			default:
 			// Do nothing

--- a/lib/Slider.js
+++ b/lib/Slider.js
@@ -547,7 +547,7 @@ export class Slider extends ShapedAssetEntity {
 
 				);
 				this.#pen.colour.fill = this.textColour;
-				this.#pen.text.print(xPos, yPos, this.#value.toString());
+				this.#pen.text._print(xPos, yPos, this.#value.toString());
 				break;
 			default:
 			// Do nothing

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -154,6 +154,20 @@ export class Text {
                     }
                     lines.push(line + firstHalf + "-");
                     line = secondHalf + " ";
+                    
+                    firstHalf = secondHalf;
+                    secondHalf = "";
+                    if (this.#pen.context.measureText(line).width > maxWidth) {
+                        while (
+                            this.#pen.context.measureText(firstHalf + "-").width > maxWidth
+                        ) {
+                            secondHalf = firstHalf[firstHalf.length - 1] + secondHalf;
+                            firstHalf = firstHalf.slice(0, -1);
+                        }
+                        lines.push(firstHalf + "-");
+                        line = secondHalf + " ";
+                    }
+                    
                 } else {
                     lines.push(line.trim());
                     line = word + " ";

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -146,28 +146,7 @@ export class Text {
                 const singleLongWord = 
                     this.#pen.context.measureText(word).width > maxWidth;
                 if (singleLongWord) { // Single word larger than max width
-                    let firstHalf = word;
-                    let secondHalf = "";
-                    while (this.#pen.context.measureText(line + firstHalf + "-").width > maxWidth) {
-                        secondHalf = firstHalf[firstHalf.length - 1] + secondHalf;
-                        firstHalf = firstHalf.slice(0, -1);
-                    }
-                    lines.push(line + firstHalf + "-");
-                    line = secondHalf + " ";
-                    
-                    firstHalf = secondHalf;
-                    secondHalf = "";
-                    if (this.#pen.context.measureText(line).width > maxWidth) {
-                        while (
-                            this.#pen.context.measureText(firstHalf + "-").width > maxWidth
-                        ) {
-                            secondHalf = firstHalf[firstHalf.length - 1] + secondHalf;
-                            firstHalf = firstHalf.slice(0, -1);
-                        }
-                        lines.push(firstHalf + "-");
-                        line = secondHalf + " ";
-                    }
-                    
+                    line = this.#addHyphenatedLines(word, line, lines, maxWidth);
                 } else {
                     lines.push(line.trim());
                     line = word + " ";
@@ -196,6 +175,31 @@ export class Text {
         }
         this.#pen.state.load();
         return "drawing with wrap";
+    }
+    // mutate by reference of lines, returns line, recursive function.
+    /**
+     * Recursive function that will add hyphenated split words to the lines array until
+     * it can fit inside the max width given.
+     * @param {string} word - The too-large word that needs to be hyphenated
+     * @param {string} line - The line previously being tested
+     * @param {string[]} lines - The array of lines for the textbox. Is mutated by this function
+     * @param {number} maxWidth - The max width given to the text, where it needs to fit inside
+     * @returns {string} - The newest line value. Will continue calling itself until reaching a line value.
+     */
+    #addHyphenatedLines(word, line, lines, maxWidth) {
+        let firstHalf = word;
+        let secondHalf = "";
+        while (this.#pen.context.measureText(line + firstHalf + "-").width > maxWidth) {
+            secondHalf = firstHalf[firstHalf.length - 1] + secondHalf;
+            firstHalf = firstHalf.slice(0, -1);
+        }
+        lines.push(line + firstHalf + "-");
+        line = secondHalf + " ";
+        if (this.#pen.context.measureText(secondHalf).width > maxWidth) {
+            return this.#addHyphenatedLines(secondHalf, "", lines, maxWidth);
+        } else {
+            return line;
+        }
     }
 
     /**

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -126,7 +126,7 @@ export class Text {
         this.#pen.context.textBaseline = this.alignment.y === "center" ? "middle" : this.alignment.y;
 
         if (this.#pen.debug) {
-            Debug.drawText(this.#pen, x, y, content);
+            Debug.drawText(this.#pen, x, y, content, maxWidth);
         }
         if (maxWidth <= 0) {
             this.#pen.context.fillText(content, x, y);
@@ -142,9 +142,9 @@ export class Text {
             const needsToWrap =
                 this.#pen.context.measureText(proposedLine).width > maxWidth;
             if (needsToWrap) {
-                if (this.#pen.debug) {
-                    Debug.drawText(this.#pen, x, y, line);
-                }
+                // if (this.#pen.debug) {
+                //     Debug.drawText(this.#pen, x, y, line);
+                // }
                 this.#pen.context.fillText(line, x, y);
                 line = word + " ";
                 y += lineHeight;
@@ -153,9 +153,9 @@ export class Text {
             }
         }
 
-        if (this.#pen.debug) {
-            Debug.drawText(this.#pen, x, y, line);
-        }
+        // if (this.#pen.debug) {
+        //     Debug.drawText(this.#pen, x, y, line);
+        // }
         this.#pen.context.fillText(line, x, y);
 
         this.#pen.state.load();

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -143,7 +143,12 @@ export class Text {
             const needsToWrap =
                 this.#pen.context.measureText(proposedLine).width > maxWidth;
             if (needsToWrap) {
-                lines.push(line.trim());
+                if (line === "") { // Single word larger than max width
+                    lines.push(proposedLine.trim());
+                    continue;
+                } else {
+                    lines.push(line.trim());
+                }
                 line = word + " ";
             } else {
                 line = proposedLine;
@@ -163,8 +168,6 @@ export class Text {
             }
             this.#pen.context.fillText(lines[i], x, y + direction);
         }
-
-        //so for center, i could just calc the beginning, like middle - height / 2, then add the height divided by how many lines
        
         if (this.#pen.debug) {
             Debug.drawText(this.#pen, x, y, content, maxWidth, lines.length);

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -1,6 +1,5 @@
 import { Debug } from "./Debug.js";
 import { Alignment } from "./Alignment.js";
-import { Colour } from "./Colour.js";
 import { Pen } from "./Pen.js";
 //errors
 import { ErrorMsgManager } from "./ErrorMessageManager.js";
@@ -46,10 +45,9 @@ export class Text {
 
         styles = styles.trim();
 
-        let size = ``;
-        size += `${this.#size}px`;
+        let size = `${this.#size}px`;
 
-        const font = `${styles} ${this.#size}px ${this.#font}`;
+        const font = `${styles} ${size} ${this.#font}`;
         return font.trim();
     }
 
@@ -89,8 +87,8 @@ export class Text {
     }
     /**
      * Draws text on the canvas. Supports optional word wrapping.
-     * @param {number} x - The x-coordinate where the text will start.
-     * @param {number} y - The y-coordinate where the text will start.
+     * @param {number} x - The x-coordinate where the text will be drawn.
+     * @param {number} y - The y-coordinate where the text will be drawn.
      * @param {string} content - The text content to be drawn.
      * @param {number} [maxWidth=0] - The maximum width allowed for the text before wrapping.
      *                                If set to 0 or left unspecified, no wrapping is applied.
@@ -189,7 +187,6 @@ export class Text {
         const fontSetting = this.#constructFont();
         this.#pen.context.font = fontSetting;
     }
-
     get font() {
         return this.#font;
     }
@@ -211,7 +208,6 @@ export class Text {
         this.#pen.context.font = this.#constructFont();
         return;
     }
-
     get bold() {
         return this.#bold;
     }
@@ -233,7 +229,6 @@ export class Text {
         this.#pen.context.font = this.#constructFont();
         return;
     }
-
     get italic() {
         return this.#italic;
     }

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -139,19 +139,27 @@ export class Text {
         let line = "";
         let lines = [];
         for (let word of words) {
-            const proposedLine = line + word + " "; //construct the new line
+            const proposedLine = line + word; //construct the new line
             const needsToWrap =
                 this.#pen.context.measureText(proposedLine).width > maxWidth;
             if (needsToWrap) {
-                if (line === "") { // Single word larger than max width
-                    lines.push(proposedLine.trim());
-                    continue;
+                const singleLongWord = 
+                    this.#pen.context.measureText(word).width > maxWidth;
+                if (singleLongWord) { // Single word larger than max width
+                    let firstHalf = word;
+                    let secondHalf = "";
+                    while (this.#pen.context.measureText(line + firstHalf + "-").width > maxWidth) {
+                        secondHalf = firstHalf[firstHalf.length - 1] + secondHalf;
+                        firstHalf = firstHalf.slice(0, -1);
+                    }
+                    lines.push(line + firstHalf + "-");
+                    line = secondHalf + " ";
                 } else {
                     lines.push(line.trim());
+                    line = word + " ";
                 }
-                line = word + " ";
             } else {
-                line = proposedLine;
+                line = proposedLine + " ";
             }
         }
         lines.push(line.trim());

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -135,28 +135,25 @@ export class Text {
         this.#pen.state.save();
         const words = content.split(" ");
         const lineHeight = this.#size;
-        let line = "";
 
+        let line = "";
+        let lines = [];
         for (let word of words) {
             const proposedLine = line + word + " "; //construct the new line
             const needsToWrap =
                 this.#pen.context.measureText(proposedLine).width > maxWidth;
             if (needsToWrap) {
-                // if (this.#pen.debug) {
-                //     Debug.drawText(this.#pen, x, y, line);
-                // }
-                this.#pen.context.fillText(line, x, y);
+                lines.push(line.trim());
                 line = word + " ";
-                y += lineHeight;
             } else {
                 line = proposedLine;
             }
         }
+        lines.push(line.trim());
 
-        // if (this.#pen.debug) {
-        //     Debug.drawText(this.#pen, x, y, line);
-        // }
-        this.#pen.context.fillText(line, x, y);
+        for (let i = 0; i < lines.length; i++) {
+            this.#pen.context.fillText(lines[i], x, y + lineHeight * i);
+        }
 
         this.#pen.state.load();
         return "drawing with wrap";

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -118,7 +118,7 @@ export class Text {
 
         //sync up the context with the alignment
         this.#pen.context.textAlign = this.alignment.x;
-        this.#pen.context.textBaseline = this.alignment.y;
+        this.#pen.context.textBaseline = this.alignment.y === "center" ? "middle" : this.alignment.y;
 
         if (this.#pen.debug) {
             Debug.drawText(this.#pen, x, y, content);

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -125,11 +125,11 @@ export class Text {
         this.#pen.context.textAlign = this.alignment.x;
         this.#pen.context.textBaseline = this.alignment.y === "center" ? "middle" : this.alignment.y;
 
-        if (this.#pen.debug) {
-            Debug.drawText(this.#pen, x, y, content, maxWidth);
-        }
         if (maxWidth <= 0) {
             this.#pen.context.fillText(content, x, y);
+            if (this.#pen.debug) {
+                Debug.drawText(this.#pen, x, y, content, maxWidth);
+            }
             return "drawing text without wrap";
         }
         this.#pen.state.save();
@@ -154,7 +154,9 @@ export class Text {
         for (let i = 0; i < lines.length; i++) {
             this.#pen.context.fillText(lines[i], x, y + lineHeight * i);
         }
-
+        if (this.#pen.debug) {
+            Debug.drawText(this.#pen, x, y, content, maxWidth, lines.length);
+        }
         this.#pen.state.load();
         return "drawing with wrap";
     }

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -13,6 +13,7 @@ export class Text {
     #font;
     #bold;
     #italic;
+    #hyphenation;
     /**
      *
      * @param {Pen} pen
@@ -32,6 +33,7 @@ export class Text {
         this.#pen.context.textBaseline = DEFAULT_BASELINE;
         this.#bold = false;
         this.#italic = false;
+        this.#hyphenation = true;
         Object.seal(this); //protect against accidental assignment;
     }
     #constructFont() {
@@ -54,6 +56,7 @@ export class Text {
     /**
      * @param {Object} newState - The new state to set.
      * @param {boolean} newState.textBold - Indicates if the text should be bold.
+     * @param {boolean} newState.textHyphenation - Indicates if the text should be hyphenated.
      * @param {boolean} newState.textItalic - Indicates if the text should be italic.
      * @param {string} newState.textAlignmentX - The horizontal alignment of the text.
      * @param {string} newState.textAlignmentY - The vertical alignment of the text.
@@ -65,6 +68,7 @@ export class Text {
             throw Error("undefined state given!");
         }
         this.bold = newState.textBold;
+        this.hyphenation = newState.textHyphenation;
         this.italic = newState.textItalic;
         this.alignment.x = newState.textAlignmentX;
         this.alignment.y = newState.textAlignmentY;
@@ -78,6 +82,7 @@ export class Text {
     get state() {
         return {
             bold: this.bold,
+            hyphenation: this.hyphenation,
             italic: this.italic,
             alignmentX: this.alignment.x,
             alignmentY: this.alignment.y,
@@ -146,7 +151,16 @@ export class Text {
                 const singleLongWord = 
                     this.#pen.context.measureText(word).width > maxWidth;
                 if (singleLongWord) { // Single word larger than max width
-                    line = this.#addHyphenatedLines(word, line, lines, maxWidth);
+                    if (this.hyphenation) {
+                        line = this.#addHyphenatedLines(word, line, lines, maxWidth);
+                    } else {
+                        if (line === "") { // Prevent long word from creating blank line
+                            lines.push(proposedLine.trim());
+                            continue;
+                        }
+                        lines.push(line.trim());
+                        line = word + " ";
+                    }
                 } else {
                     lines.push(line.trim());
                     line = word + " ";
@@ -278,6 +292,25 @@ export class Text {
     }
     get italic() {
         return this.#italic;
+    }
+
+    /**
+     * Sets whether hyphenation occurs during too-long words in multiline text. The value must be a boolean.
+     * @param {boolean} value - Indicates whether the text should be hyphenated. Default true.
+     * @returns {boolean} current hyphenation setting
+     * @throws {Error} Throws an error if the value is not a boolean.
+     */
+    set hyphenation(value) {
+        if (typeof value !== "boolean") {
+            throw new Error(
+                `Hyphenation property must be a boolean. Received: ${value}:${typeof value}`
+            );
+        }
+        this.#hyphenation = value;
+        return;
+    }
+    get hyphenation() {
+        return this.#hyphenation;
     }
 }
 

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -91,15 +91,15 @@ export class Text {
         };
     }
     /**
-     * Draws text on the canvas. Supports optional word wrapping.
+     * Draws text on the canvas. Supports optional word wrapping. INTERNAL - excludes debug drawing
      * @param {number} x - The x-coordinate where the text will be drawn.
      * @param {number} y - The y-coordinate where the text will be drawn.
      * @param {string} content - The text content to be drawn.
      * @param {number} [maxWidth=0] - The maximum width allowed for the text before wrapping.
      *                                If set to 0 or left unspecified, no wrapping is applied.
-     * @returns {string} - Returns a string indicating whether wrapping was applied.
+     * @returns {string | number} - Returns a string indicating if wrapping was applied, or the num of lines after wrapping.
      */
-    print(x, y, content, maxWidth = 0) {
+    _print(x, y, content, maxWidth = 0) {
         if (Number.isFinite(x) === false) {
             throw new Error(
                 ErrorMsgManager.numberCheckFailed(x, "x has to be a number!")
@@ -132,9 +132,6 @@ export class Text {
 
         if (maxWidth <= 0) {
             this.#pen.context.fillText(content, x, y);
-            if (this.#pen.debug) {
-                Debug.drawText(this.#pen, x, y, content, maxWidth);
-            }
             return "drawing text without wrap";
         }
         this.#pen.state.save();
@@ -183,14 +180,31 @@ export class Text {
             }
             this.#pen.context.fillText(lines[i], x, y + direction);
         }
-       
-        if (this.#pen.debug) {
-            Debug.drawText(this.#pen, x, y, content, maxWidth, lines.length);
-        }
+    
         this.#pen.state.load();
-        return "drawing with wrap";
+        return lines.length;
     }
-    // mutate by reference of lines, returns line, recursive function.
+    /**
+     * Draws text on the canvas. Supports optional word wrapping.
+     * @param {number} x - The x-coordinate where the text will be drawn.
+     * @param {number} y - The y-coordinate where the text will be drawn.
+     * @param {string} content - The text content to be drawn.
+     * @param {number} [maxWidth=0] - The maximum width allowed for the text before wrapping.
+     *                                If set to 0 or left unspecified, no wrapping is applied.
+     * @returns {string} - Returns a string indicating whether wrapping was applied.
+     */
+    print(x, y, content, maxWidth = 0) {
+        const numOfLines = this._print(x, y, content, maxWidth);
+        if (this.#pen.debug) {
+            if (maxWidth <= 0) {
+                Debug.drawText(this.#pen, x, y, content, maxWidth);
+                return "No wrapping applied";
+            } else {
+                Debug.drawText(this.#pen, x, y, content, maxWidth, numOfLines);
+                return `Wrapping applied. ${numOfLines} lines generated.`
+            }
+        }
+    }
     /**
      * Recursive function that will add hyphenated split words to the lines array until
      * it can fit inside the max width given.

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -152,8 +152,20 @@ export class Text {
         lines.push(line.trim());
 
         for (let i = 0; i < lines.length; i++) {
-            this.#pen.context.fillText(lines[i], x, y + lineHeight * i);
+            let direction = lineHeight * i;
+            if (this.alignment.y === "bottom") {
+                direction = -(lineHeight * (lines.length - 1 - i));
+            }
+            if (this.alignment.y === "center") {
+                const totalHeight = lineHeight * lines.length;
+                const adjustedY = i * lineHeight + lineHeight / 2;
+                direction = - (totalHeight / 2) + adjustedY;
+            }
+            this.#pen.context.fillText(lines[i], x, y + direction);
         }
+
+        //so for center, i could just calc the beginning, like middle - height / 2, then add the height divided by how many lines
+       
         if (this.#pen.debug) {
             Debug.drawText(this.#pen, x, y, content, maxWidth, lines.length);
         }

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -113,6 +113,13 @@ export class Text {
                 )
             );
         }
+        if ((typeof content === "string") === false) {
+            throw new Error(
+                `The content given to print must be a string! You gave ${content}, ` +
+                `which is a ${typeof content}.\nSearch for the JavaScript toString method, ` +
+                `which changes other data types to strings.\n`
+            );
+        }
 
         //sync up the context with the alignment
         this.#pen.context.textAlign = this.alignment.x;


### PR DESCRIPTION
Partial update of text:
- Fix vertical align issue where centre didn't work
- Added "string" type constraint to the print method.
- Create debug drawing for text. Draws a yellow cross where the coordinates are drawing from, a red dotted box around wrapped text (includes max width), and a grey dotted box for around the text if no wrapping.
- Update the completed GUI to work with the fixed text
- Multiline text placement works like a textbox. The coordinates are aligned with the textbox as if it was placing a rectangle (if there are 5 lines and the vertical alignment is centre, then it aligns from the middle 3rd line).
- Add hyphenation for multiline text when a single word is too long to fit within the max width.
- Created a _print function for internal use, which doesn't show debug text.