### PR TITLE
Issue 143/text enhancements

### DIFF
--- a/lib/TextArea.js
+++ b/lib/TextArea.js
@@ -107,7 +107,6 @@ export class TextArea extends ShapedAssetEntity {
 	#chars;
 	#cursorIndex;
 	#cursorVisible;
-	#arrowHoldDelay;
 	#borderWidth;
 	#padding;
 	#focused;
@@ -117,7 +116,9 @@ export class TextArea extends ShapedAssetEntity {
 	#selStartIndex;
 	#selEndIndex;
 	#keyTimers;
-	#keyHoldDelay;
+	#keyTimersModified;
+	#keyHoldDelay
+	#keyRepeatDelay;
 	#keySelectIndex;
 	#undo_history;
 	#redo_history;
@@ -141,7 +142,6 @@ export class TextArea extends ShapedAssetEntity {
      * @property {boolean} exists - True if the text area exists.
      * @property {number} x - The x-coordinate of the text area.
      * @property {number} y - The y-coordinate of the text area.
-	 * @property {number} arrowHoldDelay - The duration the arrow key needs to be held (in frames) before the scrolling starts.
 	 * @property {string} name - The name given to the text area.
 	 * @property {number} value - The current text of the text area.
      * @property {number} index - The index of the currently selected option.
@@ -154,8 +154,10 @@ export class TextArea extends ShapedAssetEntity {
 	 * @property {number} characterLimit - The optionally set limited number of chars allowed in chars array
 	 * @property {number} selStartIndex - The selection start index, corresponging to chars array, for what is currently selected by the mouse. (Not necessarily lower than end)
 	 * @property {number} selEndIndex - The selection end index, corresponging to chars array, for what is currently selected by the mouse. (Not necessarily higher than start)
-	 * @property {Object} keyTimers - An object which maps keys (String) to timers. Used for keeping track of how long keys such as ctl+V have been held down.
-	 * @property {number} keyHoldDelay - The duration a modified (ctl, shift, etc) key needs to be held (in milliseconds) before the action is repeated.
+	 * @property {Map<String, number>} keyTimers Tracks the number of milliseconds since the last key fired. Allows timing repititions.
+	 * @property {Map<String, number>} keyTimersModified - Same as keyTimers but exclusively for keyboard shortcuts.
+	 * @property {number} keyHoldDelay - The duration (in milliseconds) a key needs to be held before being repeated.
+	 * @property {number} keyRepeatDelay - The duration (in milliseconds) between each repitition of a key.
 	 * @property {number} keySelectIndex - Marks the starting index for text selected using the keyboard.
 	 * @property {Array<TextAreaState>} undo_history - Array of states representing the undo history.
 	 * @property {Array<TextAreaState>} redo_history - Array of states representing the redo history.
@@ -191,18 +193,14 @@ export class TextArea extends ShapedAssetEntity {
 
         //state managment properties
         this.#lastFrameDrawn = 0;
-		this.#arrowHoldDelay = 30;
 
-		this.#keyHoldDelay      = 150;
-		this.#keySelectIndex = -1;
-		this.#keyTimers 	    = {};
+		this.#keyTimers  	    = new Map();
+		this.#keyTimersModified = new Map();
+		this.#keyHoldDelay      = 500;
+		this.#keyRepeatDelay    = 50;
+		this.#keySelectIndex 	= -1;
 		this.#undo_history      = [];
 		this.#redo_history      = [];
-
-		for (let i="a".charCodeAt(0); i<='z'.charCodeAt(0); i++)
-		{
-			this.#keyTimers[String.fromCharCode(i)] = true;
-		}
 
         //appearance properties
         this.style = "default";
@@ -514,10 +512,50 @@ export class TextArea extends ShapedAssetEntity {
 		}
 	}
 
+	/**
+	 * Execute the callback if key and all modifiers are firing.
+	 * @param {String} key Trigger/primary key. For example, the "V" in "control + V".
+	 * @param {Array<String> | null} modifiers Array of modifier keys (for example: ["control", "shift"]).
+	 * Can be null
+	 * @param {Function} callback Callback to execute if key and all modifiers are firing.
+	 */
+	#onKeypress( key, modifiers, callback ) {
 
-	#keyReady( key ) {
-		return this.#pen.keys.down(key) && this.#keyTimers[key] <= 0;
+		let timers;
+	
+		if (modifiers == null) {
+			timers = this.#keyTimers;
+		} else {
+			timers = this.#keyTimersModified;
+			for (let modifier of modifiers) {
+				if (this.#pen.keys.down(modifier) == false) {
+					return;
+				}
+			}
+		}
+
+		if (timers.has(key) == false) {
+			timers.set(key, 0);
+
+			if (this.#pen.keys.down(key) == false) {
+				return;
+			}
+		}
+
+		// Perform action.
+		callback();
+
+		// Reset timer to appropriate value.
+		if (this.#pen.keys.down(key)) {
+			if (this.#pen.keys.durationDown(key) >= this.#keyHoldDelay) {
+				timers.set(key, this.#keyRepeatDelay);
+			} else {
+				timers.set(key, this.#keyHoldDelay);
+			}
+		}
 	}
+
+
 
 	/**
 	 * @param {Array<TextAreaState>} history 
@@ -677,42 +715,48 @@ export class TextArea extends ShapedAssetEntity {
 		}
 
 		// ctl+A
-		if (this.#keyReady("a")) {
+		this.#onKeypress("a", ["control"], () => {
 			this.#selStartIndex = 0;
 			this.#selEndIndex = this.#chars.length;
 			this.#cursorIndex = this.#selEndIndex;
-		}
+		});
 
-		// ctl+C
-		if (this.#keyReady("c")) {
-			this.#keyTimers["c"] = this.#keyHoldDelay;
-			this.#pen.text.clipboard = this.#copySelection();
-		}
+	
+		let pen = this.#pen;
 
-		// ctl+X
-		if (this.#keyReady("x")) {
-			this.#keyTimers["x"] = this.#keyHoldDelay;
-			this.#pen.text.clipboard = this.#cutSelection();
-		}
+		// ctl+C, X, V
+		this.#onKeypress("c", ["control"], () => { pen.text.clipboard = this.#copySelection(); });
+		this.#onKeypress("x", ["control"], () => { pen.text.clipboard = this.#cutSelection(); });
+		this.#onKeypress("v", ["control"], () => { this.#pasteSelection(pen.text.clipboard); });
 
-		// ctl+V
-		if (this.#keyReady("v")) {
-			this.#keyTimers["v"] = this.#keyHoldDelay;
-			this.#pasteSelection(this.#pen.text.clipboard);
-		}
-
-		// redo
-		if (this.#keyReady("z") && this.#pen.keys.down("shift")) {
-			this.#keyTimers["z"] = this.#keyHoldDelay;
-			this.#redo();
-		}
-
-		// undo
-		else if (this.#keyReady("z")) {
-			this.#keyTimers["z"] = this.#keyHoldDelay;
-			this.#undo();
+		// ctl-shift-Z, ctl-Z
+		if (this.#pen.keys.down("shift")) {
+			this.#onKeypress("z", ["control"], () => { this.#redo(); });
+		} else {
+			this.#onKeypress("z", ["control"], () => { this.#undo(); });	
 		}
 	}
+
+
+	#updateKeyTimers()
+	{ 
+		const keytimers = [this.#keyTimers, this.#keyTimersModified];
+		
+		for (let timers of keytimers) {
+			for (let [key, value] of timers) {
+
+				console.log(key, value);
+
+				if (this.#pen.keys.down(key) == false) {
+					timers.delete(key);
+				} else {
+					value = Math.max(value-this.#pen.time.msElapsed, 0);
+					timers.set(key, Math.max(value, 0));
+				}
+			}
+		}
+	}
+
 
     /**
      * Draws the text area to the canvas based on its current state.
@@ -742,20 +786,8 @@ export class TextArea extends ShapedAssetEntity {
 		);
 
 
-		// Check if keys have been released or if a sufficient amount of time has passed.
-		// If so, then they can be pressed again.
-		for (let key in this.#keyTimers) {
-			if (this.#keyTimers[key] <= 0) {
-				this.#keyTimers[key] = 0;
-				continue;
-			} else if (this.#pen.keys.released(key)) {
-				this.#keyTimers[key] = 0;
-			} else {
-				this.#keyTimers[key] -= this.#pen.time.msElapsed;
-			}
-		}
+		this.#updateKeyTimers();
 
-	
 		if (this.#focused) {
 			this.#handleOutsideClick();
 
@@ -917,8 +949,10 @@ export class TextArea extends ShapedAssetEntity {
 		}
 	}
 
-	#insertCharacter( char )
+	#insertCharacter( char, maxWidth )
 	{
+		this.#pushState(this.#undo_history);
+
 		let left  = Math.min(this.#selStartIndex, this.#selEndIndex);
 		let right = Math.max(this.#selStartIndex, this.#selEndIndex);
 		let delta = right-left;
@@ -926,11 +960,20 @@ export class TextArea extends ShapedAssetEntity {
 		this.#chars.splice(left, delta, char);
 
 		this.#keySelectIndex = left+1;
-		this.#selStartIndex     = left+1;
-		this.#selEndIndex       = left+1;
-		this.#cursorIndex       = left+1;
+		this.#selStartIndex  = left+1;
+		this.#selEndIndex    = left+1;
+		this.#cursorIndex    = left+1;
 
 		this.#cursorIndexBound();
+
+		// Move index window when typing at end of line
+		const scrolling = this.#pen.context.measureText(this.#chars.join("")).width > maxWidth;
+		if (scrolling &&
+			(this.#cursorIndex === this.#chars.length
+			|| this.#cursorIndex === this.#endIndex + 2)
+		) {
+			this.#moveWindowRight();
+		}
 	}
 
 	#backSpace()
@@ -972,26 +1015,24 @@ export class TextArea extends ShapedAssetEntity {
 			this.#focused = false;
 		}
 
+
 		// Keyboard typing inputs
 		const allowTyping = this.#characterLimit === undefined || 
 							(this.#characterLimit !== undefined && 
 							this.#chars.length !== this.#characterLimit);
 		const maxWidth = this.w - this.#borderWidth * 2 - this.#padding * 2;
 
+		for (let [key, value] of this.#keyTimers) {
+			if (value <= 0) {
+				this.#insertCharacter(key, maxWidth);
+				this.#keyTimers.set(key, this.#keyRepeatDelay);
+			}
+		}
+
 		this.#pen.keys.activeBuffer._forEach((event) => {
 			if (event.key.length === 1 && event.type === "keydown" && allowTyping) {
-				this.#pushState(this.#undo_history);
-				this.#insertCharacter(event.key);
-
-				// Move index window when typing at end of line
-				const scrolling = this.#pen.context.measureText(this.#chars.join("")).width > maxWidth;
-				if (scrolling &&
-					(this.#cursorIndex === this.#chars.length
-					|| this.#cursorIndex === this.#endIndex + 2)
-				) {
-					this.#moveWindowRight();
-				}
-				
+				this.#insertCharacter(event.key, maxWidth);
+				this.#keyTimers.set(event.key, this.#keyHoldDelay);
 			} else if (event.key === "Backspace" && event.type === "keydown") {
 				this.#pushState(this.#undo_history);
 				this.#backSpace();
@@ -1003,25 +1044,10 @@ export class TextArea extends ShapedAssetEntity {
 				}
 			}
 		});
-		// Holding arrow keys
-		const inverseScrollSpeed = 4;
-		if (this.#pen.keys.durationDown("rightarrow") > this.#arrowHoldDelay) {
-			if (this.#pen.frameCount % inverseScrollSpeed === 0){
-				this.#moveCursorRight();
-			}
-			return;
-		} else if (this.#pen.keys.durationDown("leftarrow") > this.#arrowHoldDelay) {
-			if (this.#pen.frameCount % inverseScrollSpeed === 0){
-				this.#moveCursorLeft();
-			}
-			return;
-		}
-		// Pressing arrow keys
-		if (this.#pen.keys.released("rightarrow")){
-			this.#moveCursorRight();
-		} else if (this.#pen.keys.released("leftarrow")){
-			this.#moveCursorLeft();
-		}
+
+
+		// this.#handleKeypress("leftarrow",  () => { this.#moveCursorLeft(); });
+		// this.#handleKeypress("rightarrow", () => { this.#moveCursorRight(); });
 	}
 	/**
 	 * Moves the display window (based on start and end indices) to the right, taking into

--- a/lib/TextArea.js
+++ b/lib/TextArea.js
@@ -516,7 +516,7 @@ export class TextArea extends ShapedAssetEntity {
 	 * Execute the callback if key and all modifiers are firing.
 	 * @param {String} key Trigger/primary key. For example, the "V" in "control + V".
 	 * @param {Array<String> | null} modifiers Array of modifier keys (for example: ["control", "shift"]).
-	 * Can be null
+	 * Can be null.
 	 * @param {Function} callback Callback to execute if key and all modifiers are firing.
 	 */
 	#onKeypress( key, modifiers, callback ) {
@@ -731,7 +731,7 @@ export class TextArea extends ShapedAssetEntity {
 
 		// ctl-shift-Z, ctl-Z
 		if (this.#pen.keys.down("shift")) {
-			this.#onKeypress("z", ["control"], () => { this.#redo(); });
+			this.#onKeypress("z", ["control", "shift"], () => { this.#redo(); });
 		} else {
 			this.#onKeypress("z", ["control"], () => { this.#undo(); });	
 		}
@@ -1023,9 +1023,16 @@ export class TextArea extends ShapedAssetEntity {
 		const maxWidth = this.w - this.#borderWidth * 2 - this.#padding * 2;
 
 		for (let [key, value] of this.#keyTimers) {
-			if (value <= 0) {
-				this.#insertCharacter(key, maxWidth);
-				this.#keyTimers.set(key, this.#keyRepeatDelay);
+
+			if (key != "leftarrow" && key != "rightarrow") {
+				if (value <= 0) {
+					this.#insertCharacter(key, maxWidth);
+					this.#keyTimers.set(key, this.#keyRepeatDelay);
+				}
+			} else if (key == "leftarrow") {
+				this.#moveCursorLeft();
+			} else if (key == "rightarrow")  {
+				this.#moveCursorRight();
 			}
 		}
 
@@ -1045,9 +1052,22 @@ export class TextArea extends ShapedAssetEntity {
 			}
 		});
 
+		if (this.#pen.keys.down("leftarrow")) {
+			if (this.#keyTimers.has("leftarrow") == false) {
+				this.#keyTimers.set("leftarrow", 0);
+			} else {
+				this.#keyTimers.set("leftarrow", this.#keyHoldDelay);
+			}
+		}
+	
+		if (this.#pen.keys.down("rightarrow")) {
+			if (this.#keyTimers.has("rightarrow") == false) {
+				this.#keyTimers.set("rightarrow", 0);
+			} else {
+				this.#keyTimers.set("rightarrow", this.#keyHoldDelay);
+			}
+		}
 
-		// this.#handleKeypress("leftarrow",  () => { this.#moveCursorLeft(); });
-		// this.#handleKeypress("rightarrow", () => { this.#moveCursorRight(); });
 	}
 	/**
 	 * Moves the display window (based on start and end indices) to the right, taking into

--- a/lib/TextArea.js
+++ b/lib/TextArea.js
@@ -55,17 +55,24 @@ class TextAreaUtil {
  * Stores the staate of a TextArea. Used for undo/redo functionality.
  */
 class TextAreaState {
-	chars 		  = [];
-	cursorIndex   = 0
-	selStartIndex = 0;
-	selEndIndex   = 0;
+	chars;
+	cursorIndex;
+	keySelectIndex;
+	selStartIndex;
+	selEndIndex;
+	startIndex;
+	endIndex;
 
-	constructor( chars, cursor, left, right )
+	constructor( chars, cursorIndex, keySelectIndex, selStartIndex, selEndIndex, startIndex,
+				 endIndex )
 	{
-		this.chars 		   = chars.slice();
-		this.cursorIndex   = cursor;
-		this.selStartIndex = left;
-		this.selEndIndex   = right;
+		this.chars = chars.slice();
+		this.cursorIndex = cursorIndex;
+		this.keySelectIndex = keySelectIndex;
+		this.selStartIndex = selStartIndex;
+		this.selEndIndex = selEndIndex;
+		this.startIndex = startIndex;
+		this.endIndex = endIndex;
 	}
 
 	/**
@@ -106,6 +113,8 @@ export class TextArea extends ShapedAssetEntity {
     #name;
 	#chars;
 	#cursorIndex;
+	#cursorBlinkPeriod;
+	#cursorBlinkTimer;
 	#cursorVisible;
 	#borderWidth;
 	#padding;
@@ -115,13 +124,15 @@ export class TextArea extends ShapedAssetEntity {
 	#characterLimit;
 	#selStartIndex;
 	#selEndIndex;
-	#keyTimers;
-	#keyTimersModified;
+	#keyControllers;
+	#keyctlNav;
+	#keyctlCmd;
+	#keyctlText;
 	#keyHoldDelay
 	#keyRepeatDelay;
 	#keySelectIndex;
-	#undo_history;
-	#redo_history;
+	#stateHistory;
+	#stateHistoryIndex;
 
     /**
      * Creates an instance of TextArea.
@@ -147,6 +158,7 @@ export class TextArea extends ShapedAssetEntity {
      * @property {number} index - The index of the currently selected option.
 	 * @property {string[]} chars - The array containing the text of the text area, split into characters.
 	 * @property {number} cursorIndex - The index in the chars array where the cursor is. 0 is before the first char
+	 * @property {number} cursorBlinkPeriod - The amount of time (in milliseconds) the cursor should take to complete a single blink cycle.
 	 * @property {boolean} focused - The status of whether the text area is focused on.
 	 * @property {number} padding - The padding area around the text in the text area
 	 * @property {number} startIndex - The starting index, corresponding to chars array, determining where to start display of text
@@ -154,8 +166,7 @@ export class TextArea extends ShapedAssetEntity {
 	 * @property {number} characterLimit - The optionally set limited number of chars allowed in chars array
 	 * @property {number} selStartIndex - The selection start index, corresponging to chars array, for what is currently selected by the mouse. (Not necessarily lower than end)
 	 * @property {number} selEndIndex - The selection end index, corresponging to chars array, for what is currently selected by the mouse. (Not necessarily higher than start)
-	 * @property {Map<String, number>} keyTimers Tracks the number of milliseconds since the last key fired. Allows timing repititions.
-	 * @property {Map<String, number>} keyTimersModified - Same as keyTimers but exclusively for keyboard shortcuts.
+	 * @property {TextKeyController} keyctl - Tracks the number of milliseconds since the last key fired. Allows timing repititions.
 	 * @property {number} keyHoldDelay - The duration (in milliseconds) a key needs to be held before being repeated.
 	 * @property {number} keyRepeatDelay - The duration (in milliseconds) between each repitition of a key.
 	 * @property {number} keySelectIndex - Marks the starting index for text selected using the keyboard.
@@ -187,6 +198,8 @@ export class TextArea extends ShapedAssetEntity {
 		this.#focused = false;
 		this.#chars = [];
 		this.#cursorIndex = 0;
+		this.#cursorBlinkPeriod = 175;
+		this.#cursorBlinkTimer = 0;
 		this.#cursorVisible = false;
 		this.#padding = padding;
 		this.#characterLimit = undefined;
@@ -194,13 +207,21 @@ export class TextArea extends ShapedAssetEntity {
         //state managment properties
         this.#lastFrameDrawn = 0;
 
-		this.#keyTimers  	    = new Map();
-		this.#keyTimersModified = new Map();
-		this.#keyHoldDelay      = 500;
-		this.#keyRepeatDelay    = 50;
-		this.#keySelectIndex 	= -1;
-		this.#undo_history      = [];
-		this.#redo_history      = [];
+		this.#keyHoldDelay = 500;
+		this.#keyRepeatDelay = 50;
+
+		this.#keyctlNav = new KeyInputController(pen, this.#keyHoldDelay, this.#keyRepeatDelay);
+		this.#keyctlCmd = new KeyInputController(pen, this.#keyHoldDelay, this.#keyRepeatDelay);
+		this.#keyctlText = new KeyInputController(pen, this.#keyHoldDelay, this.#keyRepeatDelay);
+		this.#keyControllers = [this.#keyctlNav, this.#keyctlCmd, this.#keyctlText];
+		this.#setupCallbacks();
+
+
+		this.#selStartIndex = 0;
+		this.#selEndIndex = 0;
+		this.#keySelectIndex = -1;
+		this.#stateHistoryIndex = -1;
+		this.#stateHistory = [];
 
         //appearance properties
         this.style = "default";
@@ -208,7 +229,7 @@ export class TextArea extends ShapedAssetEntity {
 		this.textColour = this.#pen.gui.textColour;
         this.secondaryColour = this.#pen.gui.secondaryColour;
         this.accentColour = this.#pen.gui.accentColour;
-    }
+	}
 	/**
 	 * Returns string for name property.
 	 * @returns {string}
@@ -292,6 +313,7 @@ export class TextArea extends ShapedAssetEntity {
 			)
 		}
 		this.#chars = [...tempChars];
+		this.#pushState();
 	} 
 	/**
 	 * Returns value character limit property, which is the maximum amount of characters allowed.
@@ -340,6 +362,72 @@ export class TextArea extends ShapedAssetEntity {
 		
 		this.#characterLimit = value;
 	}
+
+	#setupCallbacks() {
+		const pen = this.#pen;
+
+		this.#keyctlText.defaultCallback = (key) => {
+			if (pen.keys.down("control") == false)
+				this.#writeCharacter(key);
+		};
+
+		this.#keyctlCmd.keyCallback("leftarrow", () => {
+			if (pen.keys.down("control")) this.#jumpCursorLeft();
+			else this.#moveCursorLeft();
+		});
+
+		this.#keyctlCmd.keyCallback("rightarrow", () => {
+			if (pen.keys.down("control")) this.#jumpCursorRight();
+			else this.#moveCursorRight();
+		});
+
+		// ctl+A
+		this.#keyctlCmd.keyCallbackModified("a", ["control"], () => {
+			this.#selStartIndex = this.#startIndex;
+			this.#selEndIndex = this.#endIndex + 1;
+			this.#cursorIndex = this.#selEndIndex;
+		});
+	
+		// ctl+C, ctl+X, ctl+V
+		this.#keyctlCmd.keyCallbackModified("c", ["control"], () => { pen.text.clipboard = this.#copySelection(); });
+		this.#keyctlCmd.keyCallbackModified("x", ["control"], () => { pen.text.clipboard = this.#cutSelection(); });
+		this.#keyctlCmd.keyCallbackModified("v", ["control"], () => { this.#pasteSelection(pen.text.clipboard); });
+
+		// ctl-Z, ctl-shift-Z
+		this.#keyctlCmd.keyCallbackModified("z", ["control"], () => {
+			if (this.#pen.keys.down("shift")) this.#redo();
+			else this.#undo();
+		});
+
+		this.#keyctlCmd.keyCallback("Home", () => {
+			this.#cursorIndex=0; this.#selStartIndex=0; this.#selEndIndex=0;
+		});
+
+		this.#keyctlCmd.keyCallback("End", () => {
+			const L = this.#chars.length;
+ 			this.#cursorIndex=L; this.#selStartIndex=L; this.#selEndIndex=L;
+		});
+
+		this.#keyctlCmd.keyCallback("Backspace", () => {
+			if (this.#pen.keys.down("control") == false) {
+				this.#writeBackspace();
+				this.#pushState();
+			} else {
+				let left, right;
+
+				right = this.#cursorIndex;
+				this.#jumpCursorLeft();
+				left = this.#cursorIndex;
+				
+				this.#selStartIndex = left;
+				this.#selEndIndex   = right;
+				this.#writeBackspace();
+				this.#pushState();
+			}
+		});
+
+	}
+
     /**
      * Draws the text area's decorative elements (if any) according to theme.
      */
@@ -512,185 +600,76 @@ export class TextArea extends ShapedAssetEntity {
 		}
 	}
 
-	/**
-	 * Execute the callback if key and all modifiers are firing.
-	 * @param {String} key Trigger/primary key. For example, the "V" in "control + V".
-	 * @param {Array<String> | null} modifiers Array of modifier keys (for example: ["control", "shift"]).
-	 * Can be null.
-	 * @param {Function} callback Callback to execute if key and all modifiers are firing.
-	 */
-	#onKeypress( key, modifiers, callback ) {
-
-		let timers;
-	
-		if (modifiers == null) {
-			timers = this.#keyTimers;
-		} else {
-			timers = this.#keyTimersModified;
-			for (let modifier of modifiers) {
-				if (this.#pen.keys.down(modifier) == false) {
-					return;
-				}
-			}
-		}
-
-		if (timers.has(key) == false) {
-			timers.set(key, 0);
-
-			if (this.#pen.keys.down(key) == false) {
-				return;
-			}
-		}
-
-		// Perform action.
-		callback();
-
-		// Reset timer to appropriate value.
-		if (this.#pen.keys.down(key)) {
-			if (this.#pen.keys.durationDown(key) >= this.#keyHoldDelay) {
-				timers.set(key, this.#keyRepeatDelay);
-			} else {
-				timers.set(key, this.#keyHoldDelay);
-			}
-		}
-	}
-
-
-
-	/**
-	 * @param {Array<TextAreaState>} history 
-	 * @returns {null}
-	 */
-	#pushState( history ) {
+	#pushState() {
 		const state = new TextAreaState(
-			this.#chars, this.#cursorIndex, this.#selStartIndex, this.#selEndIndex
+			this.#chars, this.#cursorIndex, this.#keySelectIndex,
+			this.#selStartIndex, this.#selEndIndex, this.#startIndex, this.#endIndex
 		);
-		// Don't push state if identical to the previous state.
-		if (history.length > 0 && state.is_same(history[history.length-1])) {
+
+		const history = this.#stateHistory;
+		let idx = this.#stateHistoryIndex;
+		let len = idx + 1;
+
+		// Return is state is identical to the previous state.
+		if (idx >= 0 && state.is_same(history[idx])) {
 			return;
 		}
+
+		if (len < history.length) {
+			history.length = len;
+		}
+
 		history.push(state);
+		this.#stateHistoryIndex += 1;
+	
+		// console.log(`idx=${this.#stateHistoryIndex}`);
+		// console.log(history[this.#stateHistoryIndex].chars);
+		// console.log();
 	}
 
-	/**
-	 * @param {Array<TextAreaState>} history 
-	 * @returns {null}
-	 */
-	#popState( history ) {
-		if (history.length == 0) {
-			return;
-		}
-
-		const state = history[history.length-1];
+	#loadState( state ) {
 		this.#chars = state.chars.slice();
 		this.#cursorIndex = state.cursorIndex;
+		this.#keySelectIndex = state.keySelectIndex;
 		this.#selStartIndex = state.selStartIndex;
 		this.#selEndIndex = state.selEndIndex;
-
-		history.pop();
+		this.#startIndex = state.startIndex;
+		this.#endIndex = state.endIndex;
 	}
 
-	/**
-	 * Undo the last action.
-	 */
 	#undo() {
-		if (this.#undo_history.length > 0) {
-			this.#pushState(this.#redo_history);
-			this.#popState(this.#undo_history);
+		let idx = this.#stateHistoryIndex - 1;
+		let len = idx + 1;
+
+		if (len > 0) {
+			this.#loadState(this.#stateHistory[idx]);
+			this.#stateHistoryIndex = idx;
 		}
+
+		// if (this.#stateHistoryIndex+1 <= this.#stateHistory.length) {
+		// 	this.#stateHistory.pop();
+		// }
+		console.log(`idx=${this.#stateHistoryIndex}`);
 	}
 
 	/**
 	 * Redo the last undone action.
 	 */
 	#redo() {
-		if (this.#redo_history.length > 0) {
-			this.#pushState(this.#undo_history);
-			this.#popState(this.#redo_history);
+		let idx = this.#stateHistoryIndex + 1;
+		let len = idx + 1;
+
+		if (len <= this.#stateHistory.length) {
+			this.#loadState(this.#stateHistory[idx]);
+			this.#stateHistoryIndex = idx;
 		}
-	}
-
-	/**
-	 * Skip to the end of a space-separated sequence of characters.
-	 * @param {"left" | "right"} direction Direction to skip.
-	 */
-	#skipWord( direction ) {
-
-		if (direction != "left" && direction != "right")
-		{
-			throw new Error(
-				`Direction must be either "left" or "right"`
-			);
-		}
-
-		if (direction == "left") {
-			this.#cursorIndex = TextAreaUtil.findNotCharacter(" ", this.#cursorIndex-1, -1, this.#chars);
-			this.#cursorIndex = TextAreaUtil.findCharacter(" ", this.#cursorIndex, -1, this.#chars);
-		} else {
-			this.#cursorIndex = TextAreaUtil.findNotCharacter(" ", this.#cursorIndex, +1, this.#chars);
-			this.#cursorIndex = TextAreaUtil.findCharacter(" ", this.#cursorIndex, +1, this.#chars);
-		}
-
-		this.#selStartIndex = this.#cursorIndex;
-		this.#selEndIndex   = this.#cursorIndex;
-	}
-
-
-	/**
-	 * Handles navigation actions such as skipping words with ctl+arrow or home/end.
-	 */
-	#handleKeyboardNavigation() {
-		if (this.#pen.keys.down("home")) {
-			this.#cursorIndex   = 0;
-			this.#selStartIndex = 0;
-			this.#selEndIndex   = 0;
-		} else if (this.#pen.keys.down("end")) {
-			this.#cursorIndex   = this.#chars.length;
-			this.#selStartIndex = this.#chars.length;
-			this.#selEndIndex   = this.#chars.length;
-		}
-
-		if (this.#cursorIndex > this.#endIndex + 1) {
-			this.#moveWindowRight();
-		}
-		if (this.#cursorIndex < this.#startIndex) {
-			this.#moveWindowLeft();
-		}
-
-		if (this.#pen.keys.down("control") == false) {
-			return;
-		}
-
-		// jump to left side of word.
-		if (this.#pen.keys.released("leftArrow")) {
-			this.#skipWord("left");
-		}
-
-		// jump to right side of word.
-		if (this.#pen.keys.released("rightArrow")) {
-			this.#skipWord("right");
-		}
-
-		// backspace entire word.
-		if (this.#pen.keys.released("backSpace")) {
-			this.#pushState(this.#undo_history);
-
-			let left, right;
-
-			right = this.#cursorIndex;
-			this.#skipWord("left");
-			left = this.#cursorIndex;
-			
-			this.#selStartIndex = left;
-			this.#selEndIndex   = right;
-			this.#backSpace();
-		}
+		console.log(`idx=${this.#stateHistoryIndex}`);
 	}
 
 	/**
 	 * Handles shift-modified keys such as selection with the arrow keys.
 	 */
-	#handleKeyboardShiftModifier() {
+	#handleKeyboardNavigation() {
 		if (this.#pen.keys.down("shift")) {
 			if (this.#keySelectIndex == -1) {
 				this.#keySelectIndex = this.#selStartIndex;
@@ -700,60 +679,22 @@ export class TextArea extends ShapedAssetEntity {
 		} else {
 			this.#keySelectIndex = -1;
 		}
+
+		if (this.#cursorIndex > this.#endIndex + 1) {
+			this.#moveWindowRight();
+		}
+		if (this.#cursorIndex < this.#startIndex) {
+			this.#moveWindowLeft();
+		}
 	}
 
 	/**
 	 * Handles ctl-modified keys such as copy, cut and paste.
 	 */
-	#handleKeyboardCtrlModifier() {
+	#updateStateHistory() {
 		// Don't allow undo/redo history to grow too large.
-		if (this.#undo_history.length > 32) {
-			this.#undo_history.splice(0, 1);
-		}
-		if (this.#redo_history.length > 32) {
-			this.#redo_history.splice(0, 1);
-		}
-
-		// ctl+A
-		this.#onKeypress("a", ["control"], () => {
-			this.#selStartIndex = 0;
-			this.#selEndIndex = this.#chars.length;
-			this.#cursorIndex = this.#selEndIndex;
-		});
-
-	
-		let pen = this.#pen;
-
-		// ctl+C, X, V
-		this.#onKeypress("c", ["control"], () => { pen.text.clipboard = this.#copySelection(); });
-		this.#onKeypress("x", ["control"], () => { pen.text.clipboard = this.#cutSelection(); });
-		this.#onKeypress("v", ["control"], () => { this.#pasteSelection(pen.text.clipboard); });
-
-		// ctl-shift-Z, ctl-Z
-		if (this.#pen.keys.down("shift")) {
-			this.#onKeypress("z", ["control", "shift"], () => { this.#redo(); });
-		} else {
-			this.#onKeypress("z", ["control"], () => { this.#undo(); });	
-		}
-	}
-
-
-	#updateKeyTimers()
-	{ 
-		const keytimers = [this.#keyTimers, this.#keyTimersModified];
-		
-		for (let timers of keytimers) {
-			for (let [key, value] of timers) {
-
-				console.log(key, value);
-
-				if (this.#pen.keys.down(key) == false) {
-					timers.delete(key);
-				} else {
-					value = Math.max(value-this.#pen.time.msElapsed, 0);
-					timers.set(key, Math.max(value, 0));
-				}
-			}
+		if (this.#stateHistory.length > 32) {
+			this.#stateHistory.splice(1, -1);
 		}
 	}
 
@@ -785,20 +726,15 @@ export class TextArea extends ShapedAssetEntity {
 			this.h - this.#borderWidth * 2
 		);
 
-
-		this.#updateKeyTimers();
+		for (let ctl of this.#keyControllers) {
+			ctl.update();
+		}
 
 		if (this.#focused) {
 			this.#handleOutsideClick();
-
 			this.#handleKeyboardNavigation();
-			this.#handleKeyboardShiftModifier();
-
-			if (this.#pen.keys.down("control")) {
-				this.#handleKeyboardCtrlModifier();
-			} else {
-				this.#handleKeyboardInput();
-			}
+			this.#updateStateHistory();
+			this.#handleKeyboardInput();
 		}
 
 		this.#drawText(this.#startIndex, this.#endIndex); // Needs to be after keyboard input and before cursor
@@ -834,8 +770,6 @@ export class TextArea extends ShapedAssetEntity {
 	 * @returns {string} The currently selected text
 	 */
 	#cutSelection() {
-		this.#pushState(this.#undo_history);
-
 		const str  = this.#copySelection();
 		const left = Math.min(this.#selStartIndex, this.#selEndIndex);
 
@@ -843,6 +777,7 @@ export class TextArea extends ShapedAssetEntity {
 		this.#cursorIndex = left;
 		this.#selStartIndex = left;
 		this.#selEndIndex = left;
+		this.#pushState();
 
 		return str;
 	}
@@ -851,19 +786,15 @@ export class TextArea extends ShapedAssetEntity {
 	 * Paste (ctl-V) operation.
 	 * Pastes str into the char array.
 	 * @param {string} str The string to be pasted.
-	 * @returns {null}
 	 */
 	#pasteSelection( str ) {
-		this.#pushState(this.#undo_history);
-
 		const left  = Math.min(this.#selStartIndex, this.#selEndIndex);
 		const right = Math.max(this.#selStartIndex, this.#selEndIndex);
 		this.#chars.splice(left, right-left);
 
 		this.#cursorIndex = left;
 
-		for (let c of str)
-		{
+		for (let c of str) {
 			this.#chars.splice(this.#cursorIndex, 0, c);
 			this.#cursorIndex += 1;
 		}
@@ -871,6 +802,7 @@ export class TextArea extends ShapedAssetEntity {
 		this.#cursorIndex   = left + str.length;
 		this.#selStartIndex = this.#cursorIndex;
 		this.#selEndIndex   = this.#cursorIndex;
+		this.#pushState();
 	}
 
 
@@ -896,7 +828,9 @@ export class TextArea extends ShapedAssetEntity {
 	 */
 	#drawCursor() {
 		this.#pen.stroke = "transparent";
-		if (this.#pen.time.frameCount % 30 === 0) {
+		this.#cursorBlinkTimer += this.#pen.time.msElapsed;
+		if (this.#cursorBlinkTimer >= this.#cursorBlinkPeriod) {
+			this.#cursorBlinkTimer = 0;
 			this.#cursorVisible = !this.#cursorVisible;
 		}
 		if (this.#cursorVisible) {
@@ -949,9 +883,7 @@ export class TextArea extends ShapedAssetEntity {
 		}
 	}
 
-	#insertCharacter( char, maxWidth )
-	{
-		this.#pushState(this.#undo_history);
+	#writeCharacter( char, maxWidth = this.w - 2*(this.#borderWidth-this.#padding)) {
 
 		let left  = Math.min(this.#selStartIndex, this.#selEndIndex);
 		let right = Math.max(this.#selStartIndex, this.#selEndIndex);
@@ -974,9 +906,10 @@ export class TextArea extends ShapedAssetEntity {
 		) {
 			this.#moveWindowRight();
 		}
+		this.#pushState();
 	}
 
-	#backSpace()
+	#writeBackspace( maxWidth = this.w - 2*(this.#borderWidth-this.#padding) )
 	{
 		let left  = Math.min(this.#selStartIndex, this.#selEndIndex);
 		let right = Math.max(this.#selStartIndex, this.#selEndIndex);
@@ -990,12 +923,19 @@ export class TextArea extends ShapedAssetEntity {
 		}
 
 		this.#keySelectIndex = left;
-		this.#selStartIndex     = left;
-		this.#selEndIndex       = left;
-		this.#cursorIndex       = left;
+		this.#selStartIndex  = left;
+		this.#selEndIndex    = left;
+		this.#cursorIndex    = left;
 
 		this.#cursorIndexBound();
+
+		const scrolling = this.#pen.context.measureText(this.#chars.join("")).width > maxWidth;
+		// Move index window when deleting at end of line
+		if (this.#cursorIndex === this.#chars.length && scrolling) {
+			this.#moveWindowThroughDeletion();
+		}
 	}
+
 
 	/**
 	 * Handle inputs for up, down enter and esc keyboard inputs, which handle navigating options
@@ -1015,58 +955,28 @@ export class TextArea extends ShapedAssetEntity {
 			this.#focused = false;
 		}
 
-
 		// Keyboard typing inputs
 		const allowTyping = this.#characterLimit === undefined || 
 							(this.#characterLimit !== undefined && 
 							this.#chars.length !== this.#characterLimit);
 		const maxWidth = this.w - this.#borderWidth * 2 - this.#padding * 2;
 
-		for (let [key, value] of this.#keyTimers) {
-
-			if (key != "leftarrow" && key != "rightarrow") {
-				if (value <= 0) {
-					this.#insertCharacter(key, maxWidth);
-					this.#keyTimers.set(key, this.#keyRepeatDelay);
-				}
-			} else if (key == "leftarrow") {
-				this.#moveCursorLeft();
-			} else if (key == "rightarrow")  {
-				this.#moveCursorRight();
-			}
-		}
-
 		this.#pen.keys.activeBuffer._forEach((event) => {
 			if (event.key.length === 1 && event.type === "keydown" && allowTyping) {
-				this.#insertCharacter(event.key, maxWidth);
-				this.#keyTimers.set(event.key, this.#keyHoldDelay);
-			} else if (event.key === "Backspace" && event.type === "keydown") {
-				this.#pushState(this.#undo_history);
-				this.#backSpace();
-
-				const scrolling = this.#pen.context.measureText(this.#chars.join("")).width > maxWidth;
-				// Move index window when deleting at end of line
-				if (this.#cursorIndex === this.#chars.length && scrolling) {
-					this.#moveWindowThroughDeletion();
-				}
+				this.#keyctlText.resetKey(event.key);
+				this.#keyctlCmd.resetKey(event.key.toLowerCase());
+			}
+			else if (event.key == "ArrowLeft") {
+				this.#keyctlCmd.resetKey("leftarrow");
+			}
+			else if (event.key == "ArrowRight") {
+				this.#keyctlCmd.resetKey("rightarrow");
+			}
+			else if (event.key.length > 1 && event.type === "keydown") {
+				console.log(event);
+				this.#keyctlCmd.resetKey(event.key);
 			}
 		});
-
-		if (this.#pen.keys.down("leftarrow")) {
-			if (this.#keyTimers.has("leftarrow") == false) {
-				this.#keyTimers.set("leftarrow", 0);
-			} else {
-				this.#keyTimers.set("leftarrow", this.#keyHoldDelay);
-			}
-		}
-	
-		if (this.#pen.keys.down("rightarrow")) {
-			if (this.#keyTimers.has("rightarrow") == false) {
-				this.#keyTimers.set("rightarrow", 0);
-			} else {
-				this.#keyTimers.set("rightarrow", this.#keyHoldDelay);
-			}
-		}
 
 	}
 	/**
@@ -1163,6 +1073,24 @@ export class TextArea extends ShapedAssetEntity {
 		this.#selEndIndex = this.#cursorIndex;
 	}
 	/**
+	 * Skip to the left side of a space-separated sequence of characters.
+	 */
+	#jumpCursorLeft() {
+		this.#cursorIndex = TextAreaUtil.findNotCharacter(" ", this.#cursorIndex-1, -1, this.#chars);
+		this.#cursorIndex = TextAreaUtil.findCharacter(" ", this.#cursorIndex, -1, this.#chars);
+		this.#selStartIndex = this.#cursorIndex;
+		this.#selEndIndex   = this.#cursorIndex;
+	};
+	/**
+	 * Skip to the right side of a space-separated sequence of characters.
+	 */
+	#jumpCursorRight() {
+		this.#cursorIndex = TextAreaUtil.findNotCharacter(" ", this.#cursorIndex, +1, this.#chars);
+		this.#cursorIndex = TextAreaUtil.findCharacter(" ", this.#cursorIndex, +1, this.#chars);
+		this.#selStartIndex = this.#cursorIndex;
+		this.#selEndIndex   = this.#cursorIndex;
+	};
+	/**
 	 * Restrict the cursor index inside the maximum and minimum values it could be
 	 */
 	#cursorIndexBound() {
@@ -1217,3 +1145,134 @@ export class TextArea extends ShapedAssetEntity {
         );
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+class KeyInputController {
+	#defaultCallback;
+	#keyCallbacks;
+
+	#pen;
+	#holdDelay;
+	#repeatDelay;
+
+	#timers;
+	#canFire;
+	#durationDown;
+
+	/**
+	 * 
+	 * @param {Pen} pen - 
+	 * @param {number} holdDelay - 
+	 * @param {number} repeatDelay - 
+	 */
+	constructor(pen, holdDelay = 350, repeatDelay = 50 ) {
+		this.#pen = pen;
+		this.#holdDelay = holdDelay;
+		this.#repeatDelay = repeatDelay;
+
+		this.#defaultCallback = () => { };
+		this.#keyCallbacks = {};
+
+		this.#timers  = {};
+		this.#canFire = {};
+		this.#durationDown = {};
+	}
+
+	update() {
+		const timers = this.#timers;
+		const canFire = this.#canFire;
+		const durationDown = this.#durationDown;
+		const dt = this.#pen.time.msElapsed;
+
+		for (let key in timers) {
+			if (this.#pen.keys.down(key)) {
+				durationDown[key] += dt;
+				timers[key] = Math.max(timers[key]-dt, 0);
+				canFire[key] = timers[key] == 0;
+			} else {
+				timers[key] = this.#holdDelay;
+				canFire[key] = false;
+			}
+			if (canFire[key]) {
+				this.#fire(key);
+				if (durationDown[key] >= this.#holdDelay) {
+					timers[key] = this.#repeatDelay;
+				} else {
+					timers[key] = this.#holdDelay;
+				}
+			}
+
+		}
+	}
+	#validateKey( key ) {
+		if ((typeof key === "string") === false) {
+			throw Error(`key must be a string. You supplied a ${typeof key} (${key}).`);
+		}
+	}
+	/**
+	 * @param {String} key
+	 */
+	#fire( key ) {
+		if (this.#keyCallbacks[key] == undefined) {
+			this.#defaultCallback(key);
+		}
+		else if (typeof this.#keyCallbacks[key] === "function") {
+			this.#keyCallbacks[key](key);
+		}
+	}
+	/**
+	 * @param {String} key 
+	 */
+	resetKey( key ) {
+		this.#validateKey(key);
+		this.#timers[key] = 0;
+		this.#canFire[key] = true;
+		this.#durationDown[key] = 0;
+	}
+	/**
+	 * Execute the callback if key is firing.
+	 * @param {Function} callback Callback to execute if key is firing.
+	 */
+	set defaultCallback( callback ) {
+		this.#defaultCallback = callback;
+	}
+	/**
+	 * Execute the callback if key is firing.
+	 * @param {String} key Trigger/primary key. For example, the "V" in "control + V".
+	 * @param {Function} callback Callback to execute if key is firing.
+	 */
+	keyCallback( key, callback ) {
+		this.#validateKey(key);
+		this.#keyCallbacks[key] = callback;
+	}
+	/**
+	 * Execute the callback if both key and modifier are firing.
+	 * @param {String} key Trigger/primary key. For example, the "V" in "control + V".
+	 * @param {Array<String> | null} modifiers Array of modifier keys. For example, ["control", "shift"].
+	 * @param {Function} callback Callback to execute if both key and modifier are firing.
+	 */
+	keyCallbackModified( key, modifiers, callback ) {
+		this.#validateKey(key);
+		this.#keyCallbacks[key] = () => {
+			if (modifiers != null) {
+				for (let k of modifiers) {
+					if (this.#pen.keys.down(k) != true) {
+						return;
+					}
+				}
+			}
+			callback();
+		};
+	}
+
+}
+

--- a/lib/TextArea.js
+++ b/lib/TextArea.js
@@ -124,8 +124,6 @@ export class TextArea extends ShapedAssetEntity {
 	#characterLimit;
 	#selStartIndex;
 	#selEndIndex;
-	#keyControllers;
-	#keyctlNav;
 	#keyctlCmd;
 	#keyctlText;
 	#keyHoldDelay
@@ -166,12 +164,13 @@ export class TextArea extends ShapedAssetEntity {
 	 * @property {number} characterLimit - The optionally set limited number of chars allowed in chars array
 	 * @property {number} selStartIndex - The selection start index, corresponging to chars array, for what is currently selected by the mouse. (Not necessarily lower than end)
 	 * @property {number} selEndIndex - The selection end index, corresponging to chars array, for what is currently selected by the mouse. (Not necessarily higher than start)
-	 * @property {TextKeyController} keyctl - Tracks the number of milliseconds since the last key fired. Allows timing repititions.
+	 * @property {TextKeyController} keyctlText - Handles keypress timing/callbacks for plaintext typing.
+	 * @property {TextKeyController} keyctlCmd - Handles keypress timing/callbacks for keyboard commands/shortcuts.
 	 * @property {number} keyHoldDelay - The duration (in milliseconds) a key needs to be held before being repeated.
 	 * @property {number} keyRepeatDelay - The duration (in milliseconds) between each repitition of a key.
 	 * @property {number} keySelectIndex - Marks the starting index for text selected using the keyboard.
-	 * @property {Array<TextAreaState>} undo_history - Array of states representing the undo history.
-	 * @property {Array<TextAreaState>} redo_history - Array of states representing the redo history.
+	 * @property {Array<TextAreaState>} stateHistory - Array of states representing the undo/redo history.
+	 * @property {number} stateHistoryIndex - The index of the current state within stateHistory.
      * @constructor
      */
     constructor(pen, x, y, w) {
@@ -210,10 +209,8 @@ export class TextArea extends ShapedAssetEntity {
 		this.#keyHoldDelay = 500;
 		this.#keyRepeatDelay = 50;
 
-		this.#keyctlNav = new KeyInputController(pen, this.#keyHoldDelay, this.#keyRepeatDelay);
-		this.#keyctlCmd = new KeyInputController(pen, this.#keyHoldDelay, this.#keyRepeatDelay);
 		this.#keyctlText = new KeyInputController(pen, this.#keyHoldDelay, this.#keyRepeatDelay);
-		this.#keyControllers = [this.#keyctlNav, this.#keyctlCmd, this.#keyctlText];
+		this.#keyctlCmd = new KeyInputController(pen, this.#keyHoldDelay, this.#keyRepeatDelay);
 		this.#setupCallbacks();
 
 
@@ -372,13 +369,17 @@ export class TextArea extends ShapedAssetEntity {
 		};
 
 		this.#keyctlCmd.keyCallback("leftarrow", () => {
-			if (pen.keys.down("control")) this.#jumpCursorLeft();
-			else this.#moveCursorLeft();
+			if (pen.keys.down("control"))
+				this.#jumpCursorLeft();
+			else
+				this.#moveCursorLeft();
 		});
 
 		this.#keyctlCmd.keyCallback("rightarrow", () => {
-			if (pen.keys.down("control")) this.#jumpCursorRight();
-			else this.#moveCursorRight();
+			if (pen.keys.down("control"))
+				this.#jumpCursorRight();
+			else
+				this.#moveCursorRight();
 		});
 
 		// ctl+A
@@ -389,14 +390,22 @@ export class TextArea extends ShapedAssetEntity {
 		});
 	
 		// ctl+C, ctl+X, ctl+V
-		this.#keyctlCmd.keyCallbackModified("c", ["control"], () => { pen.text.clipboard = this.#copySelection(); });
-		this.#keyctlCmd.keyCallbackModified("x", ["control"], () => { pen.text.clipboard = this.#cutSelection(); });
-		this.#keyctlCmd.keyCallbackModified("v", ["control"], () => { this.#pasteSelection(pen.text.clipboard); });
+		this.#keyctlCmd.keyCallbackModified("c", ["control"], () => {
+			pen.text.clipboard = this.#copySelection();
+		});
+		this.#keyctlCmd.keyCallbackModified("x", ["control"], () => {
+			pen.text.clipboard = this.#cutSelection();
+		});
+		this.#keyctlCmd.keyCallbackModified("v", ["control"], () => {
+			this.#pasteSelection(pen.text.clipboard);
+		});
 
 		// ctl-Z, ctl-shift-Z
 		this.#keyctlCmd.keyCallbackModified("z", ["control"], () => {
-			if (this.#pen.keys.down("shift")) this.#redo();
-			else this.#undo();
+			if (this.#pen.keys.down("shift"))
+				this.#redo();
+			else
+				this.#undo();
 		});
 
 		this.#keyctlCmd.keyCallback("Home", () => {
@@ -600,6 +609,9 @@ export class TextArea extends ShapedAssetEntity {
 		}
 	}
 
+	/**
+	 * Push the current state of the TextArea onto #stateHistory.
+	 */
 	#pushState() {
 		const state = new TextAreaState(
 			this.#chars, this.#cursorIndex, this.#keySelectIndex,
@@ -621,12 +633,12 @@ export class TextArea extends ShapedAssetEntity {
 
 		history.push(state);
 		this.#stateHistoryIndex += 1;
-	
-		// console.log(`idx=${this.#stateHistoryIndex}`);
-		// console.log(history[this.#stateHistoryIndex].chars);
-		// console.log();
 	}
 
+	/**
+	 * Load a TextAreaState.
+	 * @param {TextAreaState} state 
+	 */
 	#loadState( state ) {
 		this.#chars = state.chars.slice();
 		this.#cursorIndex = state.cursorIndex;
@@ -637,6 +649,9 @@ export class TextArea extends ShapedAssetEntity {
 		this.#endIndex = state.endIndex;
 	}
 
+	/**
+	 * Undo an action by reverting to the previous state from #stateHistory.
+	 */
 	#undo() {
 		let idx = this.#stateHistoryIndex - 1;
 		let len = idx + 1;
@@ -645,15 +660,10 @@ export class TextArea extends ShapedAssetEntity {
 			this.#loadState(this.#stateHistory[idx]);
 			this.#stateHistoryIndex = idx;
 		}
-
-		// if (this.#stateHistoryIndex+1 <= this.#stateHistory.length) {
-		// 	this.#stateHistory.pop();
-		// }
-		console.log(`idx=${this.#stateHistoryIndex}`);
 	}
 
 	/**
-	 * Redo the last undone action.
+	 * Redo the previously undone action.
 	 */
 	#redo() {
 		let idx = this.#stateHistoryIndex + 1;
@@ -726,9 +736,8 @@ export class TextArea extends ShapedAssetEntity {
 			this.h - this.#borderWidth * 2
 		);
 
-		for (let ctl of this.#keyControllers) {
-			ctl.update();
-		}
+		this.#keyctlText.update();
+		this.#keyctlCmd.update();
 
 		if (this.#focused) {
 			this.#handleOutsideClick();
@@ -883,6 +892,11 @@ export class TextArea extends ShapedAssetEntity {
 		}
 	}
 
+	/**
+	 * Write a single character into #chars
+	 * @param {String} char A single char.
+	 * @param {number} maxWidth 
+	 */
 	#writeCharacter( char, maxWidth = this.w - 2*(this.#borderWidth-this.#padding)) {
 
 		let left  = Math.min(this.#selStartIndex, this.#selEndIndex);
@@ -909,6 +923,11 @@ export class TextArea extends ShapedAssetEntity {
 		this.#pushState();
 	}
 
+	/**
+	 * "Write" a backspace by deleting the appropriate characters in #chars
+	 * @param {String} char A single char.
+	 * @param {number} maxWidth 
+	 */
 	#writeBackspace( maxWidth = this.w - 2*(this.#borderWidth-this.#padding) )
 	{
 		let left  = Math.min(this.#selStartIndex, this.#selEndIndex);
@@ -959,7 +978,7 @@ export class TextArea extends ShapedAssetEntity {
 		const allowTyping = this.#characterLimit === undefined || 
 							(this.#characterLimit !== undefined && 
 							this.#chars.length !== this.#characterLimit);
-		const maxWidth = this.w - this.#borderWidth * 2 - this.#padding * 2;
+		// const maxWidth = this.w - this.#borderWidth * 2 - this.#padding * 2;
 
 		this.#pen.keys.activeBuffer._forEach((event) => {
 			if (event.key.length === 1 && event.type === "keydown" && allowTyping) {
@@ -973,7 +992,6 @@ export class TextArea extends ShapedAssetEntity {
 				this.#keyctlCmd.resetKey("rightarrow");
 			}
 			else if (event.key.length > 1 && event.type === "keydown") {
-				console.log(event);
 				this.#keyctlCmd.resetKey(event.key);
 			}
 		});
@@ -1073,7 +1091,7 @@ export class TextArea extends ShapedAssetEntity {
 		this.#selEndIndex = this.#cursorIndex;
 	}
 	/**
-	 * Skip to the left side of a space-separated sequence of characters.
+	 * Jump to the left side of a space-separated sequence of characters.
 	 */
 	#jumpCursorLeft() {
 		this.#cursorIndex = TextAreaUtil.findNotCharacter(" ", this.#cursorIndex-1, -1, this.#chars);
@@ -1082,7 +1100,7 @@ export class TextArea extends ShapedAssetEntity {
 		this.#selEndIndex   = this.#cursorIndex;
 	};
 	/**
-	 * Skip to the right side of a space-separated sequence of characters.
+	 * Jump to the right side of a space-separated sequence of characters.
 	 */
 	#jumpCursorRight() {
 		this.#cursorIndex = TextAreaUtil.findNotCharacter(" ", this.#cursorIndex, +1, this.#chars);
@@ -1169,10 +1187,9 @@ class KeyInputController {
 	#durationDown;
 
 	/**
-	 * 
-	 * @param {Pen} pen - 
-	 * @param {number} holdDelay - 
-	 * @param {number} repeatDelay - 
+	 * @param {Pen} pen
+	 * @param {number} holdDelay Number of milliseconds a key needs to be held before being repeated.
+	 * @param {number} repeatDelay Number of milliseconds between each repitition of a key.
 	 */
 	constructor(pen, holdDelay = 350, repeatDelay = 50 ) {
 		this.#pen = pen;
@@ -1230,6 +1247,7 @@ class KeyInputController {
 		}
 	}
 	/**
+	 * Reset the state of a key.
 	 * @param {String} key 
 	 */
 	resetKey( key ) {
@@ -1239,26 +1257,26 @@ class KeyInputController {
 		this.#durationDown[key] = 0;
 	}
 	/**
-	 * Execute the callback if key is firing.
-	 * @param {Function} callback Callback to execute if key is firing.
+	 * Set a default callback used by all keys without an assigned callback.
+	 * @param {Function} callback Default callback to execute when a key is pressed/repeating.
 	 */
 	set defaultCallback( callback ) {
 		this.#defaultCallback = callback;
 	}
 	/**
-	 * Execute the callback if key is firing.
+	 * Assign a callback to a specific key.
 	 * @param {String} key Trigger/primary key. For example, the "V" in "control + V".
-	 * @param {Function} callback Callback to execute if key is firing.
+	 * @param {Function} callback Callback to execute when the key is pressed/repeating.
 	 */
 	keyCallback( key, callback ) {
 		this.#validateKey(key);
 		this.#keyCallbacks[key] = callback;
 	}
 	/**
-	 * Execute the callback if both key and modifier are firing.
+	 * Assign a callback to a specific key.
 	 * @param {String} key Trigger/primary key. For example, the "V" in "control + V".
 	 * @param {Array<String> | null} modifiers Array of modifier keys. For example, ["control", "shift"].
-	 * @param {Function} callback Callback to execute if both key and modifier are firing.
+	 * @param {Function} callback Callback to execute when the key is pressed/repeating and all modifier keys are pressed.
 	 */
 	keyCallbackModified( key, modifiers, callback ) {
 		this.#validateKey(key);


### PR DESCRIPTION
- The blinking cursor now times itself in milliseconds instead of frames.
- Fixed issue where ctl+A would cause the text selection highlight to appear outside of the text area when it contains a larger amount of text.
- Pressing and holding a key will now repeatedly write that key into the character buffer.
  - Two member variables exist in TextArea for customizing this which are currently private.
  - #keyHoldDelay -Number of milliseconds a key needs to be held before being repeated.
  - #keyRepeatDelay -Number of milliseconds between each repetition of the key.
- Added a small class for managing key callbacks to the bottom of TextArea.js which TextArea now uses for plaintext typing and keyboard shortcuts/commands.
  - Executes callbacks when a key is initially pressed and then periodically after some specified duration (uses previous point).
- Did additional testing on the undo/redo functionality of TextArea and found problems so I re-implemented it.  I was initially using two stacks of states, one for undo and one for redo, but that ended up being quite error prone. It now uses a single array and keeps track of an index representing the current state. This works well as the index is just decremented/incremented to undo/redo an action.
