### PR TITLE
Can pass mouse as parameter to collider.overlaps and collider.collides

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TaD | 👩🏽‍🏫 & ✏️</title>
-    <script src="./js/playground/textAreaTest.js" type="module" defer></script>
+    <script src="./js/playground/mouseOverlapTest.js" type="module" defer></script>
     <style>
         html, body {
             margin:0px;

--- a/js/playground/mouseOverlapTest.js
+++ b/js/playground/mouseOverlapTest.js
@@ -1,0 +1,26 @@
+import { $ } from "../../lib/Pen.js";
+
+$.use(update);
+$.w = 1024;
+$.h = 1024;
+
+$.debug=false;
+
+const A = $.makeBoxCollider($.w/2 - 128, $.h/2, 64, 64);
+const B = $.makeBoxCollider($.w/2 + 128, $.h/2, 64, 64);
+
+function update() {
+    if (A.collides($.mouse)) {
+        A.fill = "rgb(100, 100, 255)";
+    } else {
+        A.fill = "rgb(255, 255, 255)";
+    }
+
+    if (B.overlaps($.mouse)) {
+        B.fill = "rgb(100, 255,  100)";
+    } else {
+        B.fill = "rgb(255, 255, 255)";
+    }
+
+    $.drawColliders();
+}

--- a/lib/Collider.js
+++ b/lib/Collider.js
@@ -6,6 +6,7 @@ import { CollisionUtilities } from "./CollisionUtilities.js";
 
 //errors
 import { ErrorMsgManager } from "./ErrorMessageManager.js";
+import { Mouse } from "./Mouse.js";
 
 export class Collider extends ShapedAssetEntity {
     static all = null;
@@ -113,10 +114,13 @@ export class Collider extends ShapedAssetEntity {
 
     /**
      * 
-     * @param {Collider} otherCollider 
+     * @param {Collider | Mouse} otherCollider 
      * @returns {boolean}
      */
     overlaps(otherCollider) {
+        if (otherCollider instanceof Mouse) {
+            otherCollider = otherCollider.collider;
+        }
         if (otherCollider instanceof Group) {
             return otherCollider.overlaps(this);
         }
@@ -130,10 +134,13 @@ export class Collider extends ShapedAssetEntity {
     
     /**
      * 
-     * @param {Collider} otherCollider 
+     * @param {Collider | Mouse} otherCollider 
      * @returns {boolean}
      */
     collides(otherCollider) {
+        if (otherCollider instanceof Mouse) {
+            otherCollider = otherCollider.collider;
+        }
         if (otherCollider instanceof Collider) {
             return this.#pen.getCollisionManager().collidesOrOverlapsColliderToCollider(this, otherCollider, false);
         }

--- a/lib/Mouse.js
+++ b/lib/Mouse.js
@@ -12,6 +12,8 @@ export class Mouse extends InputDevice {
     #wheelDelta;
     #fill;
     #stroke;
+    #collider;
+
     constructor(pen) {
         super(pen);
         this.pen = pen;
@@ -62,6 +64,19 @@ export class Mouse extends InputDevice {
     get rightReleased() {
         return this.#rightReleased;
     }
+
+    get collider() {
+        // In the future it may be worth looking into changing this into a group
+        // of three colliders which conform to the shape of the cursor.
+
+        if (this.#collider === undefined) {
+            this.#collider = this.pen.makeCircleCollider(0, 0, 16);
+            this.#collider.static = true;
+        }
+
+        return this.#collider;
+    }
+
     /**
      * private_internal
      */
@@ -135,6 +150,11 @@ export class Mouse extends InputDevice {
                 this.x + SIZE,
                 this.y + SIZE
             );
+
+            this.collider.position.x = (3*this.x + SIZE)/3;
+            this.collider.position.y = (3*this.y + 2.5*SIZE)/3;
+            // this.collider.rotation = 180.0 * (Math.atan2(this.y-this.y+SIZE, this.x-this.x+SIZE) / Math.PI);
+
             this.pen.state.load();
         }
         this.endOfFrame();


### PR DESCRIPTION
- Added a circle collider to the mouse. 
- .overlaps and .collides checks if the parameter is an instance of Mouse and uses mouse.collider if so.

I couldn't see an easy way to determine if a point overlaps with a box collider (due to rotation). It may be there but I'm not sure. Currently it is just a circle collider that roughly fits the cursor. If composite colliders are supported in the future a more so a more tightly fitting shape could be composed of multiple box colliders. 