### PR TITLE
$.width and $.height being reset by pen

### DIFF
--- a/js/playground/textAreaTest.js
+++ b/js/playground/textAreaTest.js
@@ -1,9 +1,9 @@
 import { $ } from "../../lib/Pen.js";
 // $.debug = true;
 
+$.h = 512;
+$.w = 512;
 $.use(update);
-$.width  = 512;
-$.height = 512;
 
 
 const textArea = $.makeTextArea(256, 256, 300, 300);
@@ -28,6 +28,7 @@ function update() {
 	$.text.print(175, 40, "- shift + home/end");
 
 	$.text.print(350, 20,  "- home/end");
+	$.text.print(350, 40,  String(`w, h = ${$.w}, ${$.h}`));
 
 	textArea.draw();
 	textArea.characterLimit = 300;

--- a/lib/Pen.js
+++ b/lib/Pen.js
@@ -74,11 +74,15 @@ export class Pen {
     #overallStyle;
 
     constructor(
+        //launch static checker eventually.
         draw = () => {
             console.warn("no user made function for draw given!");
         }
     ) {
         this.canvas = document.getElementById("myCanvas");
+        this.width = 800;
+        this.height = 600;
+
         // @ts-ignore
         this.context = this.canvas.getContext("2d");
 
@@ -579,10 +583,6 @@ ${Video.loading.title} | ${Video.loading.url}
      * private_internal
      */
     setupCanvas() {
-        //launch static checker eventually.
-        this.width = 800;
-        this.height = 600;
-
         //set up the entity all group done here due to hoisting issues
         // @ts-ignore
         if (!Entity.all) {


### PR DESCRIPTION
Fixed issue where calling $.use would reset the canvas dimensions to 800x600, even after they had been set by the user.