### PR TITLE
Fixed issue 165

### DIFF
--- a/js/playground/textAreaTest.js
+++ b/js/playground/textAreaTest.js
@@ -1,5 +1,5 @@
 import { $ } from "../../lib/Pen.js";
-// $.debug = true;
+$.debug = true;
 
 $.use(update);
 $.width  = 512;

--- a/lib/PerformanceMetrics.js
+++ b/lib/PerformanceMetrics.js
@@ -125,8 +125,8 @@ export class PerformanceMetrics {
 
     constructor() {
         this.#metrics = {};
-        this.addMetric(new MetricGroupVsArray());
-        this.addMetric(new MetricFramerate());
+        // this.addMetric(new MetricGroupVsArray());
+        // this.addMetric(new MetricFramerate());
 
         this.#trends = {};
         this.#measurements = {};


### PR DESCRIPTION
PerformanceMetrics by default includes an expensive test which is run every 1024 frames if pen.debug is enabled. I've commented-out the part of the PerformanceMetrics constructor that adds these tests as they can instead be passed to PerformanceMetrics externally in a test program.